### PR TITLE
[Whizard] fix two bugs for W-bosons

### DIFF
--- a/python/Generators/Whizard.py
+++ b/python/Generators/Whizard.py
@@ -235,7 +235,7 @@ class Whizard(GeneratorBase):
                     lepton_type=lepton_type.capitalize() 
                 return f"{lepton_type}{flavor}"
             elif apdg > 20:
-                particle_mapping = {22: "gamma", 23: "Z", 25: "H", 24: "W-", -24: "W+"}
+                particle_mapping = {22: "gamma", 23: "Z", 25: "H", 24: "Wp", -24: "Wm"}
                 return particle_mapping.get(pdg, f"Cant find whizard id for pdg {pdg}")
             elif apdg <= 6:
                 return self.whizard_quarks(pdg)


### PR DESCRIPTION
BEGINRELEASENOTES
Fixed two bugs for W-bosons
 - PDG 24 is W+ not W-
 - `+, -` are interpreted as operators in Sindarin if not escaped properly. It is easier to use `Wm, Wp`.
  See: https://whizard.hepforge.org/manual/manual006.html#sec144

ENDRELEASENOTES
