### PR TITLE
Make `main.py` executable and create a symlink during installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,9 +87,19 @@ configure_file(
 install(DIRECTORY ${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}/ DESTINATION ${CMAKE_INSTALL_BINDIR}  FILES_MATCHING PATTERN "*env.sh*" )
 
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/python
-  DESTINATION python
-  REGEX test_.*\\.py$ EXCLUDE  # Don't install python unittests
+  DESTINATION ${CMAKE_INSTALL_PREFIX}
+  REGEX test_.*\\.py|main.py$ EXCLUDE  # Don't install python unittests
   PATTERN __pycache__ EXCLUDE  # Or pythons caches
 )
+# Install main as an executable
+install(PROGRAMS ${PROJECT_SOURCE_DIR}/python/main.py DESTINATION ${CMAKE_INSTALL_PREFIX}/python)
+
+install(CODE "execute_process(COMMAND bash -c \"set -e
+    link_target=${CMAKE_INSTALL_PREFIX}/python/main.py
+    link_name=${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_BINDIR}/k4GeneratorsConfig
+    rm -f $link_name
+    ln -s $link_target $link_name
+    \")")
+
 # Install the share directory to make them easily accessible
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/share DESTINATION ${CMAKE_INSTALL_DATADIR}/${CMAKE_PROJECT_NAME})

--- a/python/Generators/Babayaga.py
+++ b/python/Generators/Babayaga.py
@@ -1,5 +1,5 @@
-from GeneratorBase import GeneratorBase
-import BabayagaProcDB
+from .GeneratorBase import GeneratorBase
+from . import BabayagaProcDB
 
 
 class Babayaga(GeneratorBase):

--- a/python/Generators/Generators.py
+++ b/python/Generators/Generators.py
@@ -1,9 +1,9 @@
-import Sherpa
-import Whizard
-import Madgraph
-import Babayaga
-import KKMC
-import Pythia
+from . import Sherpa
+from . import Whizard
+from . import Madgraph
+from . import Babayaga
+from . import KKMC
+from . import Pythia
 
 
 class Generators:

--- a/python/Generators/KKMC.py
+++ b/python/Generators/KKMC.py
@@ -1,5 +1,5 @@
-from GeneratorBase import GeneratorBase
-import KKMCProcDB
+from .GeneratorBase import GeneratorBase
+from . import KKMCProcDB
 import os, sys
 
 
@@ -93,7 +93,7 @@ class KKMC(GeneratorBase):
             self.GeneratorDatacardName,
             self.GeneratorDatacardBase,
             self.procinfo.get("output_format"),
-            self.procinfo.get("events")
+            self.procinfo.get("events"),
         )
         key4hepRun += "$K4GenBuildDir/bin/convertHepMC2EDM4HEP -i {0} -o edm4hep {1}.{0} {1}.edm4hep\n".format(
             self.procinfo.get("output_format"), self.GeneratorDatacardBase

--- a/python/Generators/Madgraph.py
+++ b/python/Generators/Madgraph.py
@@ -1,5 +1,5 @@
-from GeneratorBase import GeneratorBase
-import MadgraphProcDB
+from .GeneratorBase import GeneratorBase
+from . import MadgraphProcDB
 from Particles import Particle as part
 
 

--- a/python/Generators/Pythia.py
+++ b/python/Generators/Pythia.py
@@ -1,5 +1,5 @@
-from GeneratorBase import GeneratorBase
-import PythiaProcDB
+from .GeneratorBase import GeneratorBase
+from . import PythiaProcDB
 
 
 class Pythia(GeneratorBase):

--- a/python/Generators/Sherpa.py
+++ b/python/Generators/Sherpa.py
@@ -1,5 +1,5 @@
-from GeneratorBase import GeneratorBase
-import SherpaProcDB
+from .GeneratorBase import GeneratorBase
+from . import SherpaProcDB
 
 
 class Sherpa(GeneratorBase):

--- a/python/Generators/Whizard.py
+++ b/python/Generators/Whizard.py
@@ -1,5 +1,5 @@
-from GeneratorBase import GeneratorBase
-import WhizardProcDB
+from .GeneratorBase import GeneratorBase
+from . import WhizardProcDB
 
 
 class Whizard(GeneratorBase):

--- a/python/Generators/__init__.py
+++ b/python/Generators/__init__.py
@@ -1,0 +1,5 @@
+from . import Generators as _generators_module
+
+Generators = _generators_module.Generators
+
+__all__ = ["Generators"]

--- a/python/Process.py
+++ b/python/Process.py
@@ -1,5 +1,5 @@
 from Particles import Particle
-from CirceHelper import CirceHelper
+from Generators.CirceHelper import CirceHelper
 
 
 class Process:

--- a/python/main.py
+++ b/python/main.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import os
 import sys
 import argparse

--- a/python/main.py
+++ b/python/main.py
@@ -5,11 +5,6 @@ import sys
 import argparse
 import textwrap
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "Tools")))
-sys.path.insert(
-    1, os.path.abspath(os.path.join(os.path.dirname(__file__), "Generators"))
-)
-
 import Input as Settings
 import Process as process_module
 import Generators as generators_module
@@ -93,7 +88,7 @@ Beamstrahlung        : string (name of accelerator: ILC, FCC, CLIC, C3, HALFHF)
     files = args.f
     energies = args.ecms
     ecmsfiles = args.ecmsFiles
-    rndmSeed  = args.seed
+    rndmSeed = args.seed
     events = args.nevts
 
     # so additionallt we read the argument ecmsFile
@@ -107,7 +102,7 @@ Beamstrahlung        : string (name of accelerator: ILC, FCC, CLIC, C3, HALFHF)
         executeFiles(files, 0, rndmSeed, events)
     else:
         for sqrts in energies:
-            rndmIncrement = executeFiles(files,sqrts,rndmSeed,events)
+            rndmIncrement = executeFiles(files, sqrts, rndmSeed, events)
             # offset for next round by number of yaml files
             rndmSeed = rndmSeed + rndmIncrement
 

--- a/python/main.py
+++ b/python/main.py
@@ -85,6 +85,8 @@ Beamstrahlung        : string (name of accelerator: ILC, FCC, CLIC, C3, HALFHF)
         help="Number of events to be generated",
     )
     args = parser.parse_args()
+    if not args.f:
+        parser.error('No input file specified, needed to define the processes, add to the command line: -f YAMLFILE ')
     files = args.f
     energies = args.ecms
     ecmsfiles = args.ecmsFiles


### PR DESCRIPTION
BEGINRELEASENOTES
- Mark `main.py` as executable and create a symlink from `<prefix>/bin/k4GeneratorsConfig` to `<prefix>/python/main.py` during installation. This makes it possible to setup an environment where `k4GeneratorsConfig` can be used as a simple executable
- Remove some `PYTHONPATH` modifications from within the interpreter and use absolute imports. This makes it possible to simply add `<prefix>/pyhton` to the `PYTHONPATH` and everything will work.
  - Now we use relative imports internally mostly and make sure to expose `Generators.Generators` via settings in `__init__.py`

ENDRELEASENOTES

One thing I discovered that simply calling `<prefix>/bin/k4GeneratorsConfig` without argument, leads to:
```console
$ ./install/bin/k4GeneratorsConfig 
Generating and writing configuration files
Traceback (most recent call last):
  File "/home/tmadlener/work/key4hep/k4GeneratorsConfig/./install/bin/k4GeneratorsConfig", line 158, in <module>
    main()
  File "/home/tmadlener/work/key4hep/k4GeneratorsConfig/./install/bin/k4GeneratorsConfig", line 102, in main
    executeFiles(files, 0, rndmSeed, events)
  File "/home/tmadlener/work/key4hep/k4GeneratorsConfig/./install/bin/k4GeneratorsConfig", line 154, in executeFiles
    return rndmIncrement
           ^^^^^^^^^^^^^
UnboundLocalError: cannot access local variable 'rndmIncrement' where it is not associated with a value
```

Ideally this should simply spit out a usage message, rather than error. Things work with `-h` or `--help`. Maybe there is an easy way to fix this, by e.g. making some of the arguments required, in which case `argparse` would do the right thing.

- [ ] name of `k4GeneratorsConfig` symlink? See also dicsussion in https://github.com/key4hep/key4hep-spack/issues/617
- [ ] Also update the setup.sh script?

