### PR TITLE
Install subdirectory of share

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,4 +92,4 @@ install(DIRECTORY ${PROJECT_SOURCE_DIR}/python
   PATTERN __pycache__ EXCLUDE  # Or pythons caches
 )
 # Install the share directory to make them easily accessible
-install(DIRECTORY ${PROJECT_SOURCE_DIR}/share DESTINATION ${CMAKE_INSTALL_DATADIR}/${CMAKE_PROJECT_NAME})
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/share/ECFAHiggsFactories DESTINATION ${CMAKE_INSTALL_DATADIR}/${CMAKE_PROJECT_NAME})


### PR DESCRIPTION
Otherwise the result will be `<prefix>/share/k4GeneratorsConfig/share/ECFAHiggsFactories`. This removes the extra `share` and the result becomes `<prefix>/share/k4GeneratorsConfig/ECFAHiggsFactories`. with spack this will then be accessible via `$K4GENERATORSCONFIG/ECFAHiggsFactories`
