### PR TITLE
Require a lower version of cmake since we don't use features from v3.27

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.27)
+cmake_minimum_required(VERSION 3.25)
 
 project(k4GeneratorsConfig)
 


### PR DESCRIPTION
I am trying to build on MacOS and we have an older version of cmake. I was able to build `k4GeneratorsConfig` with 3.25, so I'm lowering to that (real requirement may be lower).

BEGINRELEASENOTES
- Require a lower version of cmake since we don't use features from v3.27

ENDRELEASENOTES