### PR TITLE
Making help work plus other minor fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,10 +22,10 @@ find_package(ZLIB)
 find_package(LibLZMA)
 find_package(BZip2)
 
-#--- Define basic build settings -----------------------------------------------
 # - Use GNU-style hierarchy for installing build products
 include(GNUInstallDirs)
 
+#--- Define basic build settings -----------------------------------------------
 include(cmake/Key4hepConfig.cmake)
 
 # Build the converter

--- a/k4GeneratorsConfig/src/key4HEPAnalysis.cxx
+++ b/k4GeneratorsConfig/src/key4HEPAnalysis.cxx
@@ -126,10 +126,10 @@ int main(int argc, char** argv) {
   for (size_t i = 0; i < reader->getEntries(podio::Category::Event); ++i) {
     if (i)
       event = podio::Frame(reader->readNextEntry(podio::Category::Event));
-    auto& mcParticles = event.get<edm4hep::MCParticleCollection>(edm4hep::labels::MCParticles);
+    const auto& mcParticles = event.get<edm4hep::MCParticleCollection>(edm4hep::labels::MCParticles);
     // do more stuff with this event
-    edm4hep::LorentzVectorM* particleA;
-    edm4hep::LorentzVectorM* particleB;
+    edm4hep::LorentzVectorM* particleA = nullptr;
+    edm4hep::LorentzVectorM* particleB = nullptr;
     for (auto part : mcParticles) {
       if (part.getPDG() == particlesList[0] && !particleA) {
         auto momentumA = part.getMomentum();
@@ -150,15 +150,12 @@ int main(int argc, char** argv) {
         pzpdgapdgb->Fill(pp.pz());
       }
     }
+
     // release memory after an event
-    if (particleA) {
-      delete particleA;
-      particleA = 0;
-    }
-    if (particleB) {
-      delete particleB;
-      particleB = 0;
-    }
+    delete particleA;
+    particleA = nullptr;
+    delete particleB;
+    particleB = nullptr;
   }
 
   // now analyze the event

--- a/k4GeneratorsConfig/src/pythiaLHERunner.cxx
+++ b/k4GeneratorsConfig/src/pythiaLHERunner.cxx
@@ -156,7 +156,7 @@ int main(int argc, char** argv) {
   // Done.
   if (!hepmc) {
     std::cout << "pythiaLHErunner::WARNING: HepMC output not allowed.\n"
-              << "         To allow HepMC output make sure you have this line " << "in your Pythia command file:\n"
+              << "         To allow HepMC output make sure you have this line in your Pythia command file:\n"
               << "           Main:writeHepMC = on" << std::endl;
   }
 

--- a/k4GeneratorsConfig/src/pythiaRunner.cxx
+++ b/k4GeneratorsConfig/src/pythiaRunner.cxx
@@ -100,7 +100,7 @@ int main(int argc, char** argv) {
         continue;
       }
 
-      std::cout << "pythiaRunner::ERROR: Event generation aborted prematurely, " << "owing to error!\n"
+      std::cout << "pythiaRunner::ERROR: Event generation aborted prematurely, owing to error!\n"
                 << "                     Aborting..." << std::endl;
       exit(1);
     }

--- a/k4GeneratorsConfig/src/pythiaRunner.cxx
+++ b/k4GeneratorsConfig/src/pythiaRunner.cxx
@@ -1,79 +1,88 @@
-// main07.cc is a part of the PYTHIA event generator.
-// Copyright (C) 2024 Torbjorn Sjostrand.
-// PYTHIA is licenced under the GNU GPL v2 or later, see COPYING for details.
-// Please respect the MCnet Guidelines, see GUIDELINES for details.
+// k4GeneratorsConfig
+#include "pythiaUserHooks.h"
 
-// Keywords: two-body decay; astroparticle; python; matplotlib
-
-// Illustration how to generate various two-body channels from
-// astroparticle processes, e.g. neutralino annihilation or decay.
-// To this end a "blob" of energy is created with unit cross section,
-// from the fictitious collision of two non-radiating incoming e+e-.
-// In the accompanying main29.cmnd file the decay channels of this
-// blob can be set up. Furthermore, only gamma, e+-, p/pbar and
-// neutrinos are stable, everything else is set to decay.
-// (The "single-particle gun" of main21.cc offers another possible
-// approach to the same problem.)
-// Also illustrated output to be plotted by Python/Matplotlib/pyplot.
-
+// Pythia8
 #include "Pythia8/Pythia.h"
 #include "Pythia8Plugins/HepMC3.h"
 #include <unistd.h>
 
-#include "pythiaUserHooks.h"
+// std
+#include <string>
 
-using namespace Pythia8;
-
-//==========================================================================
+// *nix
+#include <unistd.h>
 
 int main(int argc, char** argv) {
+  // Default values for the command-line arguments
+  std::string pythiaCmdFilePath = "Pythia.dat";
+  bool verbose = false;
 
-  // read the options
-  std::string filename = "Pythia.dat";
+  // Read the command-line arguments
   int c;
-  while ((c = getopt(argc, argv, "f:")) != -1)
+  while ((c = getopt(argc, argv, "f:vh")) != -1) {
     switch (c) {
     case 'f':
-      filename = optarg;
+      pythiaCmdFilePath = std::string(optarg);
+      break;
+    case 'v':
+      verbose = true;
       break;
     case 'h':
-      std::cout << "Usage: pythiaRunner -h -f filename" << std::endl;
-      std::cout << "-h: print this help" << std::endl;
-      std::cout << "-f filename: file containing the pythia commands" << std::endl;
-      exit(0);
     default:
+      std::cout << "Usage: pythiaRunner [-h, -v] -f FILEPATH\n"
+                << "  -h: print this help and exit\n"
+                << "  -v: more verbose output\n"
+                << "  -f FILEPATH: file containing the Pythia commands" << std::endl;
+
       exit(0);
     }
-  // check existence of the file:
-  std::ifstream infile(filename);
-  if (infile.fail()) {
-    std::cout << "pythiaRunner:: input file with name " << filename << " not found. Exiting" << std::endl;
-    exit(0);
   }
 
-  // Pythia generator.
-  Pythia pythia;
-  // add the write hepmc flag to the settings
+  // Print input/output filepaths
+  if (verbose) {
+    std::cout << "pythiaRunner::INFO: Input Pythia command file: " << pythiaCmdFilePath << std::endl;
+  }
+
+  // Check if the Pythia file can be read
+  {
+    std::ifstream infile(pythiaCmdFilePath);
+    if (!infile.good()) {
+      std::cout << "pythiaRunner::ERROR: Input Pythia command file with name \"" << pythiaCmdFilePath
+                << "\" cannot be read!\n"
+                << "                     Exiting..." << std::endl;
+      exit(1);
+    }
+    infile.close();
+  }
+
+  // Pythia generator
+  Pythia8::Pythia pythia;
+
+  // Add the write HepMC flag to the settings
   pythia.settings.addFlag("Main:writeHepMC", false);
   pythia.settings.addWord("Main:HepMCFile", "pythia");
   pythia.settings.addWord("Main:SelectorsFile", "PythiaSelectors");
-  // Read in the rest of the settings and data from a separate file.
-  pythia.readFile(filename);
+
+  // Read in the rest of the settings and data from a separate file
+  pythia.readFile(pythiaCmdFilePath);
 
   // setup the Userhooks for PYTHIA
   const std::string selectorFile = pythia.word("Main:SelectorsFile");
   auto pythiaUserHooksPtr = make_shared<pythiaUserHooks>(selectorFile);
   bool success = pythia.setUserHooksPtr(pythiaUserHooksPtr);
-  if (!success)
-    std::cout << "WARNING::pythiaRunner::setting of UserHooks was unsuccessful: " << std::endl;
+  if (!success) {
+    std::cout << "WARNING::pythiaRunner::setting of UserHooks was unsuccessful!" << std::endl;
+  }
 
-  // Initialization.
+  // Initialization
   pythia.init();
 
-  // check for hepmc
+  // Check for HepMC output
   const bool hepmc = pythia.flag("Main:writeHepMC");
   const std::string hepmcFile = pythia.word("Main:HepMCFile");
-  std::cout << "HEPMC file name is " << hepmcFile << std::endl;
+  if (verbose) {
+    std::cout << "pythiaRunner::INFO: File path of the output HepMC file is \"" << hepmcFile << "\"" << std::endl;
+  }
   Pythia8::Pythia8ToHepMC ToHepMC;
   if (hepmc)
     ToHepMC.setNewFile(hepmcFile);
@@ -85,15 +94,17 @@ int main(int argc, char** argv) {
   // Begin event loop.
   int iAbort = 0;
   for (int iEvent = 0; iEvent < nEvent; ++iEvent) {
-
     // Generate events. Quit if many failures.
     if (!pythia.next()) {
-
-      if (++iAbort < nAbort)
+      if (++iAbort < nAbort) {
         continue;
-      cout << " Event generation aborted prematurely, owing to error!\n";
-      break;
+      }
+
+      std::cout << "pythiaRunner::ERROR: Event generation aborted prematurely, " << "owing to error!\n"
+                << "                     Aborting..." << std::endl;
+      exit(1);
     }
+
     // event was ok, write to hepmc file
     if (hepmc) {
       ToHepMC.writeNextEvent(pythia);
@@ -108,7 +119,8 @@ int main(int argc, char** argv) {
   return 0;
 }
 
-/*! derived from main07.cmnd.
+/*
+! derived from main07.cmnd.
 ! This file contains commands to be read in for a Pythia8 run.
 ! Lines not beginning with a letter or digit are comments.
 

--- a/k4GeneratorsConfig/src/pythiaUserHooks.cxx
+++ b/k4GeneratorsConfig/src/pythiaUserHooks.cxx
@@ -156,7 +156,7 @@ bool pythiaUserHooks::Veto1ParticleSelector(double energy, double px, double py,
         if (!(value < m_Value[i]))
           vetoed = true;
       } else {
-        std::cout << "pythiaUserHooks::Vecto1Particle Comparator request " << "unknown " << m_Comparator[i]
+        std::cout << "pythiaUserHooks::Vecto1Particle Comparator request unknown " << m_Comparator[i]
                   << std::endl;
       }
     }

--- a/k4GeneratorsConfig/src/pythiaUserHooks.cxx
+++ b/k4GeneratorsConfig/src/pythiaUserHooks.cxx
@@ -195,7 +195,7 @@ bool pythiaUserHooks::Veto2ParticleSelector(double energy1, double px1, double p
         if (!(value < m_Value[i]))
           vetoed = true;
       } else {
-        std::cout << "pythiaUserHooks::Veto2Particles Comparator request " << "unknown " << m_Comparator[i]
+        std::cout << "pythiaUserHooks::Veto2Particles Comparator request unknown " << m_Comparator[i]
                   << std::endl;
       }
     }

--- a/k4GeneratorsConfig/src/pythiaUserHooks.cxx
+++ b/k4GeneratorsConfig/src/pythiaUserHooks.cxx
@@ -82,7 +82,7 @@ pythiaUserHooks::pythiaUserHooks(std::string filename) : m_isValid(true) {
       }
     }
   } else {
-    std::cout << "pythiaUserHooks::file could not be opened, not applying user " << "cuts!" << std::endl;
+    std::cout << "pythiaUserHooks::file could not be opened, not applying user cuts!" << std::endl;
     m_isValid = false;
   }
   theFile.close();

--- a/k4GeneratorsConfig/src/pythiaUserHooks.cxx
+++ b/k4GeneratorsConfig/src/pythiaUserHooks.cxx
@@ -91,7 +91,7 @@ pythiaUserHooks::pythiaUserHooks(std::string filename) : m_isValid(true) {
   if (m_NbOfParticles.size() != m_PDGID1.size() || m_PDGID1.size() != m_PDGID2.size() ||
       m_PDGID1.size() != m_Value.size() || m_Value.size() != m_Type.size()) {
     m_isValid = false;
-    std::cout << "Inconsistent definition of 1 particle selector in " << "pythiaUserHooks" << std::endl;
+    std::cout << "Inconsistent definition of 1 particle selector in pythiaUserHooks" << std::endl;
   }
 
   print();

--- a/k4GeneratorsConfig/src/pythiaUserHooks.cxx
+++ b/k4GeneratorsConfig/src/pythiaUserHooks.cxx
@@ -1,6 +1,8 @@
+// std
 #include <fstream>
 #include <iostream>
 
+// k4GeneratorsConfig
 #include "pythiaUserHooks.h"
 
 pythiaUserHooks::pythiaUserHooks(std::string filename) : m_isValid(true) {
@@ -8,9 +10,9 @@ pythiaUserHooks::pythiaUserHooks(std::string filename) : m_isValid(true) {
   std::cout << "pythiaUserHooks to restrict phase space instantiated from file " << filename << std::endl;
 
   std::string line;
-  std::string delimiter = " ";
   std::ifstream theFile(filename);
   if (theFile.is_open()) {
+    std::string delimiter = " ";
     while (getline(theFile, line)) {
       //      std::cout << line << std::endl;
       size_t pos = 0;
@@ -80,38 +82,42 @@ pythiaUserHooks::pythiaUserHooks(std::string filename) : m_isValid(true) {
       }
     }
   } else {
-    std::cout << "pythiaUserHooks::file could not be opened, not applying user cuts" << std::endl;
+    std::cout << "pythiaUserHooks::file could not be opened, not applying user " << "cuts!" << std::endl;
     m_isValid = false;
   }
+  theFile.close();
 
-  // check consistency
+  // Check consistency
   if (m_NbOfParticles.size() != m_PDGID1.size() || m_PDGID1.size() != m_PDGID2.size() ||
       m_PDGID1.size() != m_Value.size() || m_Value.size() != m_Type.size()) {
     m_isValid = false;
-    std::cout << "Inconsistent definition of 1 particle selector in pythiaUserHooks" << std::endl;
+    std::cout << "Inconsistent definition of 1 particle selector in " << "pythiaUserHooks" << std::endl;
   }
 
   print();
 }
+
 pythiaUserHooks::~pythiaUserHooks() {}
 
 bool pythiaUserHooks::canVetoProcessLevel() { return true; }
 
 bool pythiaUserHooks::doVetoProcessLevel(Pythia8::Event& event) {
-  // if the selectors are not configured correctly, do not veto...
+  // If the selectors are not configured correctly, do not veto
   if (!m_isValid)
     return false;
-  // ensure that the veto is called
+
+  // Ensure that the veto is called
   for (int i = 0; i < event.size(); i++) {
-    Particle part1 = event[i];
+    Pythia8::Particle part1 = event[i];
     if (part1.status() > 0) {
-      // if we see a veto reason do not waist time and return a veto, otherwirse continue
+      // if we see a veto reason do not waist time and return a veto,
+      // otherwise continue
       if (Veto1ParticleSelector(part1.e(), part1.px(), part1.py(), part1.pz(), part1.id())) {
         return true;
       }
     }
     for (int j = 0; j < event.size(); j++) {
-      Particle part2 = event[j];
+      Pythia8::Particle part2 = event[j];
       if (i != j && part1.status() > 0 && part2.status() > 0) {
         if (Veto2ParticleSelector(part1.e(), part1.px(), part1.py(), part1.pz(), part1.id(), part2.e(), part2.px(),
                                   part2.py(), part2.pz(), part2.id())) {
@@ -125,7 +131,6 @@ bool pythiaUserHooks::doVetoProcessLevel(Pythia8::Event& event) {
 }
 
 bool pythiaUserHooks::Veto1ParticleSelector(double energy, double px, double py, double pz, int pdg) {
-
   bool vetoed = false;
   for (unsigned int i = 0; i < m_PDGID1.size(); i++) {
     if (m_NbOfParticles[i] != 1)
@@ -151,15 +156,16 @@ bool pythiaUserHooks::Veto1ParticleSelector(double energy, double px, double py,
         if (!(value < m_Value[i]))
           vetoed = true;
       } else {
-        std::cout << "pythiaUserHooks::Vecto1Particle Comparator request unknown " << m_Comparator[i] << std::endl;
+        std::cout << "pythiaUserHooks::Vecto1Particle Comparator request " << "unknown " << m_Comparator[i]
+                  << std::endl;
       }
     }
   }
   return vetoed;
 }
+
 bool pythiaUserHooks::Veto2ParticleSelector(double energy1, double px1, double py1, double pz1, int pdg1,
                                             double energy2, double px2, double py2, double pz2, int pdg2) {
-
   bool vetoed = false;
   for (unsigned int i = 0; i < m_PDGID1.size(); i++) {
     if (m_NbOfParticles[i] != 2)
@@ -189,7 +195,8 @@ bool pythiaUserHooks::Veto2ParticleSelector(double energy1, double px1, double p
         if (!(value < m_Value[i]))
           vetoed = true;
       } else {
-        std::cout << "pythiaUserHooks::Veto2Particles Comparator request unknown " << m_Comparator[i] << std::endl;
+        std::cout << "pythiaUserHooks::Veto2Particles Comparator request " << "unknown " << m_Comparator[i]
+                  << std::endl;
       }
     }
   }
@@ -197,27 +204,29 @@ bool pythiaUserHooks::Veto2ParticleSelector(double energy1, double px1, double p
 }
 
 double pythiaUserHooks::PT(double px, double py) {
-
   double pt = px * px + py * py;
+
   if (pt >= 0) {
     pt = sqrt(pt);
   } else {
     pt = 0;
   }
+
   return pt;
 }
-double pythiaUserHooks::ET(double energy, double px, double py, double pz) {
 
+double pythiaUserHooks::ET(double energy, double px, double py, double pz) {
   double et = energy * sin(Theta(px, py, pz));
 
   return et;
 }
-double pythiaUserHooks::Rapidity(double energy, double pz) {
 
+double pythiaUserHooks::Rapidity(double energy, double pz) {
   double rap = 0.5 * log((energy + pz) / (energy - pz));
 
   return rap;
 }
+
 double pythiaUserHooks::Theta(double px, double py, double pz) {
 
   double costheta = 0.;
@@ -233,16 +242,16 @@ double pythiaUserHooks::Theta(double px, double py, double pz) {
 
   return theta;
 }
-double pythiaUserHooks::Eta(double px, double py, double pz) {
 
+double pythiaUserHooks::Eta(double px, double py, double pz) {
   double theta = Theta(px, py, pz);
   double eta = -log(tan(theta / 2.));
 
   return eta;
 }
+
 double pythiaUserHooks::Mass(double energy1, double px1, double py1, double pz1, double energy2, double px2, double py2,
                              double pz2) {
-
   double mass = (energy1 + energy2) * (energy1 + energy2) - (px1 + px2) * (px1 + px2) - (py1 + py2) * (py1 + py2) -
                 (pz1 + pz2) * (pz1 + pz2);
   if (mass > 0.) {
@@ -265,7 +274,6 @@ double pythiaUserHooks::Angle(double px1, double py1, double pz1, double px2, do
 }
 
 void pythiaUserHooks::print() {
-
   std::cout << "pythiaUserHooks::Single Particle Selectors" << std::endl;
   for (unsigned int i = 0; i < m_PDGID1.size(); i++) {
     std::cout << "PDGID: " << m_PDGID1[i] << " ";

--- a/k4GeneratorsConfig/src/pythiaUserHooks.h
+++ b/k4GeneratorsConfig/src/pythiaUserHooks.h
@@ -1,24 +1,24 @@
 #ifndef K4GENERATORSCONFIG_PYTHIAUSERHOOKS_H
 #define K4GENERATORSCONFIG_PYTHIAUSERHOOKS_H
 
+// std
 #include <string>
-
+#include <vector>
+// Pythia8
 #include "Pythia8/Pythia.h"
 
-using namespace Pythia8;
-
-class pythiaUserHooks : public UserHooks {
+class pythiaUserHooks : public Pythia8::UserHooks {
 
 public:
-  // Constructor creates anti-kT jet finder with (-1, R, pTmin, etaMax).
-  pythiaUserHooks(std::string);
+  // Constructor creates anti-kT jet finder with (-1, R, pTmin, etaMax)
+  explicit pythiaUserHooks(std::string);
 
   // Destructor deletes anti-kT jet finder and prints histograms.
   ~pythiaUserHooks();
 
   // we work at the parton level
   bool canVetoProcessLevel();
-  bool doVetoProcessLevel(Event&);
+  bool doVetoProcessLevel(Pythia8::Event&);
 
   bool Veto1ParticleSelector(double, double, double, double, int);
   bool Veto2ParticleSelector(double, double, double, double, int, double, double, double, double, int);
@@ -40,8 +40,8 @@ private:
   std::vector<unsigned int> m_NbOfParticles;
   std::vector<int> m_PDGID1;
   std::vector<int> m_PDGID2;
-  std::vector<string> m_Type;
-  std::vector<string> m_Comparator;
+  std::vector<std::string> m_Type;
+  std::vector<std::string> m_Comparator;
   std::vector<double> m_Value;
 };
 


### PR DESCRIPTION
Hi,
recently we found `pythiaRunner` and `pythiaLHERunner` quite useful for a quick running of the Pythia8. This PR just fixes few issues (should not alter the functionality) and a lot of unnecessary tabs :)
  * making -h work for pythiaRunner and pythiaLHERunner
  * Exiting with non zero return code when there is an error
  * Adds `cmake/Key4hepConfig.cmake`, which helps with undefined shared libraries when the package is actually installed
  * Adds few warnings
  * Resolves undefined behaviours in few places

Why is it required, that user specifies `Main:writeHepMC` in their Pythia command file for `pythiaLHERunner`?

BEGINRELEASENOTES
- Make -h (help) work for `pythiaRunner` and `pythiaLHERunner`

ENDRELEASENOTES
