### PR TITLE
Use the same formatting settings for c++ code as in other Key4hep repositories

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,236 @@
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    true
+AlignConsecutiveBitFields:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
+AlignConsecutiveDeclarations:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
+AlignConsecutiveMacros:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  PadOperators:    false
+AlignConsecutiveShortCaseStatements:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCaseColons: false
+AlignEscapedNewlines: Right
+AlignOperands:   Align
+AlignTrailingComments:
+  Kind:            Always
+  OverEmptyLines:  0
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortEnumsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+AttributeMacros:
+  - __capability
+BinPackArguments: true
+BinPackParameters: true
+BitFieldColonSpacing: Both
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterExternBlock: false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakAfterAttributes: Never
+BreakAfterJavaFieldAnnotations: false
+BreakArrays:     true
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: Always
+BreakBeforeBraces: Attach
+BreakBeforeInlineASMColon: OnlyMultiline
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+BreakInheritanceList: BeforeColon
+BreakStringLiterals: true
+ColumnLimit:     120
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
+IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseBlocks: false
+IndentCaseLabels: false
+IndentExternBlock: AfterExternBlock
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentRequiresClause: true
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+InsertBraces:    false
+InsertNewlineAtEOF: false
+InsertTrailingCommas: None
+IntegerLiteralSeparator:
+  Binary:          0
+  BinaryMinDigits: 0
+  Decimal:         0
+  DecimalMinDigits: 0
+  Hex:             0
+  HexMinDigits:    0
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+KeepEmptyLinesAtEOF: false
+LambdaBodyIndentation: Signature
+LineEnding:      DeriveLF
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: Inner
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PackConstructorInitializers: BinPack
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyIndentedWhitespace: 0
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+PPIndentWidth:   -1
+QualifierAlignment: Leave
+ReferenceAlignment: Pointer
+ReflowComments:  true
+RemoveBracesLLVM: false
+RemoveParentheses: Leave
+RemoveSemicolon: false
+RequiresClausePosition: OwnLine
+RequiresExpressionIndentation: OuterScope
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SortIncludes:    CaseSensitive
+SortJavaStaticImport: Before
+SortUsingDeclarations: LexicographicNumeric
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeJsonColon: false
+SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  AfterRequiresInClause: false
+  AfterRequiresInExpression: false
+  BeforeNonEmptyParentheses: false
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  Never
+SpacesInContainerLiterals: true
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParens:  Never
+SpacesInParensOptions:
+  InCStyleCasts:   false
+  InConditionalStatements: false
+  InEmptyParentheses: false
+  Other:           false
+SpacesInSquareBrackets: false
+Standard:        Latest
+StatementAttributeLikeMacros:
+  - Q_EMIT
+StatementMacros:
+  - Q_UNUSED
+  - QT_REQUIRE_VERSION
+TabWidth:        8
+UseTab:          Never
+VerilogBreakBetweenInstancePorts: true
+WhitespaceSensitiveMacros:
+  - BOOST_PP_STRINGIZE
+  - CF_SWIFT_NAME
+  - NS_SWIFT_NAME
+  - PP_STRINGIZE
+  - STRINGIZE
+...
+

--- a/.github/scripts/clang-format-hook
+++ b/.github/scripts/clang-format-hook
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Thin wrapper around clang-format for easier to parse output from the
+# pre-commit hook.
+#
+# Needs to work with multiple input files as pre-commit passes multiple files to
+# the "executables"
+
+# Make sure that diff is actually recent enough (diffutils >= 3.4) to support
+# colored output
+COLOR_OUTPUT=$(diff --color=always <(echo) <(echo) > /dev/null 2>&1 && echo "--color=always")
+
+success=0
+for file in ${@}; do
+    if ! $(clang-format --style=file --Werror --dry-run ${file} > /dev/null 2>&1); then
+        echo "Necessary changes for: '${file}' (run 'clang-format --style=file -i ${file}' to fix it)"
+        diff ${COLOR_OUTPUT} -u ${file} <(clang-format --style=file ${file}) | tail -n +3
+        success=1
+    fi
+done
+exit ${success}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,25 @@
+name: pre-commit
+
+on: [push, pull_request]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: cvmfs-contrib/github-action-cvmfs@v5
+    - uses: aidasoft/run-lcg-view@v5
+      with:
+        container: el9
+        view-path: /cvmfs/sw-nightlies.hsf.org/key4hep
+        run: |
+          export PYTHONPATH=$(python -m site --user-site):$PYTHONPATH
+          export PATH=/root/.local/bin:$PATH
+          # Newer versions of git are more cautious around the github runner
+          # environment and without this git rev-parse --show-cdup in pre-commit
+          # fails
+          git config --global --add safe.directory $(pwd)
+          pip install pre-commit
+          pre-commit run --show-diff-on-failure \
+            --color=always \
+            --all-files

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,7 @@ image: python:latest
 
 before_script:
   - python --version ; pip --version  # For debugging
-  - pip install virtualenv 
+  - pip install virtualenv
   - virtualenv venv
   - source venv/bin/activate
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.4.0
+    hooks:
+      - id: mixed-line-ending
+      - id: trailing-whitespace
+        exclude: (doc/ReleaseNotes.md|k4GeneratorsConfig/src/cmdline\..|\.template|ref-results)
+  - repo: local
+    hooks:
+      - id: clang-format
+        name: clang-format
+        entry: .github/scripts/clang-format-hook
+        types: [c++]
+        exclude: (k4GeneratorsConfig/src/cmdline\..)
+        language: system

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A python based module for the automatic generation of inputfiles for  Monte-Carl
 
 ## Requirements
 `Python >= 3.7`
-`PyYaml`  
+`PyYaml`
 
 Check your python version
 ```
@@ -18,7 +18,7 @@ pip3 install pyyaml --user
 ```
 
 ## Usage
-Before begining, you should setup the environment by: 
+Before begining, you should setup the environment by:
 ```
 source /path/to/k4GeneratorsConfig/setup.(tc)(z)sh
 ```
@@ -45,7 +45,7 @@ cd /path/to/out
 ```
 Warning: always run this scheme as cmake and make set up the environment variables correctly for the execution of the generation step
 
-## Running tests: 
+## Running tests:
 You can test the creation of the input files and the event generation step:
 ```
 bash
@@ -70,7 +70,7 @@ The following are a list of user settings that are common to all event generator
 
 - **ISRMode**: Enable ISR via electron structure function:
 ```
-ISRMode: 1 
+ISRMode: 1
 ```
 default: 0 (turned off)
 
@@ -80,7 +80,7 @@ default: 0 (turned off)
 
 - **Events**: Number of Monte-Carlo events to be generated.
 
-- **Processes**: A list of processes which runcards should be generated. Each process should have its own unique name. Under these headings you can 
+- **Processes**: A list of processes which runcards should be generated. Each process should have its own unique name. Under these headings you can
 				 specify the final states to be generated and at what order e.g [EW,QCD].
 ```
 		Processes:
@@ -135,7 +135,7 @@ default: 0 (turned off)
 
   - **Two Particle Selectors**:
   	- **Mass**: Cut on the invariant mass of two particles
-  	- **Angle**: Cut on the angular separation in radians 
+  	- **Angle**: Cut on the angular separation in radians
   	- **DEta**: Cut on the pseudorapidity separation
   	- **DY**: Cut on the rapidity separation
   	- **DPhi**: Cut on the azimuthal separation in radians

--- a/examples/FermionProduction.yaml
+++ b/examples/FermionProduction.yaml
@@ -23,18 +23,18 @@ Processes:
      Final: [14, -14]
      Order: [2,0]
      ISRMode: 1
-  
+
   Tau91.2:
      Final: [15, -15]
      Order: [2,0]
      ISRMode: 1
-     
+
   Muon350:
      Final: [13, -13]
      Order: [2,0]
      SqrtS: 350
      ISRMode: 1
-     
+
   MuonNeutrino350:
      Final: [14, -14]
      Order: [2,0]

--- a/examples/TTbarProduction.yaml
+++ b/examples/TTbarProduction.yaml
@@ -26,7 +26,7 @@ Processes:
      RandomSeed: 42
      SqrtS: 1000
      ISRMode: 1
-     
+
 
 
 

--- a/examples/ZHDecay.yaml
+++ b/examples/ZHDecay.yaml
@@ -19,8 +19,8 @@ Processes:
      Final: [23, 25]
      Order: [2,0]
      RandomSeed: 42
-     SqrtS: 250 
-     Decay: 
+     SqrtS: 250
+     Decay:
       23:
         - 13
         - -13
@@ -31,8 +31,8 @@ Processes:
      Final: [23, 25]
      Order: [2,0]
      RandomSeed: 42
-     SqrtS: 350 
-     Decay: 
+     SqrtS: 350
+     Decay:
       23:
         - 13
         - -13

--- a/k4GeneratorsConfig/src/WriterEDM4HEP.cxx
+++ b/k4GeneratorsConfig/src/WriterEDM4HEP.cxx
@@ -9,7 +9,6 @@
 ///
 #include <cstring>
 
-
 #include "HepMC3/GenEvent.h"
 #include "HepMC3/GenParticle.h"
 #include "HepMC3/GenVertex.h"
@@ -19,82 +18,68 @@
 #include "WriterEDM4HEP.h"
 
 #include "edm4hep/Constants.h"
-#include "edm4hep/GeneratorToolInfo.h"
 #include "edm4hep/GeneratorEventParametersCollection.h"
 #include "edm4hep/GeneratorPdfInfoCollection.h"
+#include "edm4hep/GeneratorToolInfo.h"
 
-#include "edm4hep/MCParticleCollection.h"
 #include "edm4hep/EventHeaderCollection.h"
+#include "edm4hep/MCParticleCollection.h"
 
-#include "HepPDT/ParticleID.hh"
 #include "HepMC3/Attribute.h"
+#include "HepPDT/ParticleID.hh"
 
 #include "podio/Frame.h"
 
-namespace HepMC3
-{
+namespace HepMC3 {
 
-
-WriterEDM4HEP::WriterEDM4HEP(const std::string &filename, std::shared_ptr<GenRunInfo> run)
-    : m_file(filename),
-      m_stream(&m_file),
-      m_particle_counter(0),
-      m_edm4hepWriterClosed(false),
-      m_edm4hepWriter(filename)
-{
-    HEPMC3_WARNING("WriterEDM4HEP::WriterEDM4HEP: the conversion to EDM4HEP is still being developed")
-    set_run_info(run);
-    if ( !run_info() ) set_run_info(std::make_shared<GenRunInfo>());
-    if ( !m_file.is_open() )
-    {
-        HEPMC3_ERROR("WriterEDM4HEP: could not open output file: " << filename )
-    }
+WriterEDM4HEP::WriterEDM4HEP(const std::string& filename, std::shared_ptr<GenRunInfo> run)
+    : m_file(filename), m_stream(&m_file), m_particle_counter(0), m_edm4hepWriterClosed(false),
+      m_edm4hepWriter(filename) {
+  HEPMC3_WARNING("WriterEDM4HEP::WriterEDM4HEP: the conversion to EDM4HEP is still being developed")
+  set_run_info(run);
+  if (!run_info())
+    set_run_info(std::make_shared<GenRunInfo>());
+  if (!m_file.is_open()) {
+    HEPMC3_ERROR("WriterEDM4HEP: could not open output file: " << filename)
+  }
 }
 
-WriterEDM4HEP::WriterEDM4HEP(std::ostream &stream, std::shared_ptr<GenRunInfo> run)
-    : m_stream(&stream),
-      m_particle_counter(0),
-      m_edm4hepWriterClosed(false),
-      m_edm4hepWriter("")
-{
-    HEPMC3_WARNING("WriterEDM4HEP::WriterEDM4HEP: HepMC2 IO_GenEvent format is outdated. Please use HepMC3 Asciiv3 format instead.")
-    set_run_info(run);
-    if ( !run_info() ) set_run_info(std::make_shared<GenRunInfo>());
-    const std::string header = "HepMC::Version " + version() + "\nHepMC::IO_GenEvent-START_EVENT_LISTING\n";
-    m_stream->write(header.data(), header.length());
+WriterEDM4HEP::WriterEDM4HEP(std::ostream& stream, std::shared_ptr<GenRunInfo> run)
+    : m_stream(&stream), m_particle_counter(0), m_edm4hepWriterClosed(false), m_edm4hepWriter("") {
+  HEPMC3_WARNING(
+      "WriterEDM4HEP::WriterEDM4HEP: HepMC2 IO_GenEvent format is outdated. Please use HepMC3 Asciiv3 format instead.")
+  set_run_info(run);
+  if (!run_info())
+    set_run_info(std::make_shared<GenRunInfo>());
+  const std::string header = "HepMC::Version " + version() + "\nHepMC::IO_GenEvent-START_EVENT_LISTING\n";
+  m_stream->write(header.data(), header.length());
 }
 
 WriterEDM4HEP::WriterEDM4HEP(std::shared_ptr<std::ostream> s_stream, std::shared_ptr<GenRunInfo> run)
-    : m_shared_stream(s_stream),
-      m_stream(s_stream.get()),
-      m_particle_counter(0),
-      m_edm4hepWriterClosed(false),
-      m_edm4hepWriter("")
-{
-    HEPMC3_WARNING("WriterEDM4HEP::WriterEDM4HEP: HepMC2 IO_GenEvent format is outdated. Please use HepMC3 Asciiv3 format instead.")
-    set_run_info(run);
-    if ( !run_info() ) set_run_info(std::make_shared<GenRunInfo>());
-    const std::string header = "HepMC::Version " + version() + "\nHepMC::IO_GenEvent-START_EVENT_LISTING\n";
-    m_stream->write(header.data(), header.length());
+    : m_shared_stream(s_stream), m_stream(s_stream.get()), m_particle_counter(0), m_edm4hepWriterClosed(false),
+      m_edm4hepWriter("") {
+  HEPMC3_WARNING(
+      "WriterEDM4HEP::WriterEDM4HEP: HepMC2 IO_GenEvent format is outdated. Please use HepMC3 Asciiv3 format instead.")
+  set_run_info(run);
+  if (!run_info())
+    set_run_info(std::make_shared<GenRunInfo>());
+  const std::string header = "HepMC::Version " + version() + "\nHepMC::IO_GenEvent-START_EVENT_LISTING\n";
+  m_stream->write(header.data(), header.length());
 }
 
-
-WriterEDM4HEP::~WriterEDM4HEP()
-{
-  if ( !m_edm4hepWriterClosed )
+WriterEDM4HEP::~WriterEDM4HEP() {
+  if (!m_edm4hepWriterClosed)
     close();
 }
 
-
-void WriterEDM4HEP::write_event(const GenEvent &evt) 
-{
+void WriterEDM4HEP::write_event(const GenEvent& evt) {
 
   // make sure run_info is up to date
-  if ( !run_info() ) {
+  if (!run_info()) {
     set_run_info(evt.run_info());
     write_run_info();
   }
-  if ( evt.run_info() && run_info() != evt.run_info() ) {
+  if (evt.run_info() && run_info() != evt.run_info()) {
     set_run_info(evt.run_info());
     write_run_info();
   }
@@ -105,8 +90,9 @@ void WriterEDM4HEP::write_event(const GenEvent &evt)
   edm4hep::MCParticleCollection particleCollection;
 
   std::map<unsigned int, edm4hep::MutableMCParticle> mapIDPart;
-  for (auto hepmcParticle:evt.particles()) {
-    //    std::cout << "Converting hepmc particle with Pdg_ID " << hepmcParticle->pdg_id() << "and id " <<  hepmcParticle->id() << std::endl;
+  for (auto hepmcParticle : evt.particles()) {
+    //    std::cout << "Converting hepmc particle with Pdg_ID " << hepmcParticle->pdg_id() << "and id " <<
+    //    hepmcParticle->id() << std::endl;
     if (mapIDPart.find(hepmcParticle->id()) == mapIDPart.end()) {
       edm4hep::MutableMCParticle edm_particle = transformParticle(hepmcParticle);
       mapIDPart.insert({hepmcParticle->id(), edm_particle});
@@ -114,7 +100,7 @@ void WriterEDM4HEP::write_event(const GenEvent &evt)
     // mother/daughter links
     auto prodvertex = hepmcParticle->production_vertex();
     if (nullptr != prodvertex) {
-      for (auto particle_mother: prodvertex->particles_in()) {
+      for (auto particle_mother : prodvertex->particles_in()) {
         if (mapIDPart.find(particle_mother->id()) == mapIDPart.end()) {
           edm4hep::MutableMCParticle edm_particle = transformParticle(particle_mother);
           mapIDPart.insert({particle_mother->id(), edm_particle});
@@ -124,7 +110,7 @@ void WriterEDM4HEP::write_event(const GenEvent &evt)
     }
     auto endvertex = hepmcParticle->end_vertex();
     if (nullptr != endvertex) {
-      for (auto particle_daughter: endvertex->particles_out()) {
+      for (auto particle_daughter : endvertex->particles_out()) {
         if (mapIDPart.find(particle_daughter->id()) == mapIDPart.end()) {
           auto edm_particle = transformParticle(particle_daughter);
           mapIDPart.insert({particle_daughter->id(), edm_particle});
@@ -134,7 +120,7 @@ void WriterEDM4HEP::write_event(const GenEvent &evt)
     }
   }
 
-  for (auto particle_pair: mapIDPart){
+  for (auto particle_pair : mapIDPart) {
     particleCollection.push_back(particle_pair.second);
   }
 
@@ -146,11 +132,11 @@ void WriterEDM4HEP::write_event(const GenEvent &evt)
   evtHeader.setEventNumber(evt.event_number());
 
   // add the weights
-  for (auto weight: evt.weights()){
+  for (auto weight : evt.weights()) {
     evtHeader.addToWeights(weight);
   }
   // the eventheader weight has to be set separately
-  if ( evt.weights().size() > 0 ) {
+  if (evt.weights().size() > 0) {
     evtHeader.setWeight(evt.weights()[0]);
   }
 
@@ -165,59 +151,59 @@ void WriterEDM4HEP::write_event(const GenEvent &evt)
   edm4hep::MutableGeneratorEventParameters generatorParameters;
 
   // add the cross sections and its errors as parameter vector to the Frame
-  if ( evt.cross_section() ) {
-    for (auto xsec: evt.cross_section()->xsecs()){
+  if (evt.cross_section()) {
+    for (auto xsec : evt.cross_section()->xsecs()) {
       generatorParameters.addToCrossSections(xsec);
     }
-    for (auto xsecErr: evt.cross_section()->xsec_errs()){
+    for (auto xsecErr : evt.cross_section()->xsec_errs()) {
       generatorParameters.addToCrossSectionErrors(xsecErr);
     }
   }
 
   // add the event_scale
   std::string name = "event_scale";
-  generatorParameters.setEventScale(retrieveDoubleAttribute(evt,name));
+  generatorParameters.setEventScale(retrieveDoubleAttribute(evt, name));
 
   // add SQRTS
-  double sqrts = 0.; 
-  if ( evt.beams().size()==2 ) {
+  double sqrts = 0.;
+  if (evt.beams().size() == 2) {
     ConstGenParticlePtr beam1 = evt.beams()[0];
     ConstGenParticlePtr beam2 = evt.beams()[1];
-    sqrts = (beam1->momentum()+beam2->momentum()).m();
+    sqrts = (beam1->momentum() + beam2->momentum()).m();
   }
   // special treatement for MADGRAPH: overwrite beams to get the SQRTS correctly
-  if ( run_info()->tools().size() > 0 ) {
-    if ( run_info()->tools()[0].name.find("MadGraph") != std::string::npos){
-      sqrts = retrieveDoubleAttribute(evt,"EBMUP1") + retrieveDoubleAttribute(evt,"EBMUP2");
+  if (run_info()->tools().size() > 0) {
+    if (run_info()->tools()[0].name.find("MadGraph") != std::string::npos) {
+      sqrts = retrieveDoubleAttribute(evt, "EBMUP1") + retrieveDoubleAttribute(evt, "EBMUP2");
     }
   }
   // now we write to the structure:
   generatorParameters.setSqrts(sqrts);
 
-  //signal process ID
+  // signal process ID
   name = "signal_process_id";
-  generatorParameters.setSignalProcessId(retrieveIntAttribute(evt,name));
+  generatorParameters.setSignalProcessId(retrieveIntAttribute(evt, name));
 
-  //signal vertex ID
+  // signal vertex ID
   name = "signal_vertex_id";
-  bool convertOK = writeSignalVertex(evt,retrieveIntAttribute(evt,name),mapIDPart,generatorParameters);
+  bool convertOK = writeSignalVertex(evt, retrieveIntAttribute(evt, name), mapIDPart, generatorParameters);
   // inconsistent use of attributes, fallback for SHERPA
-  if ( !convertOK ){
+  if (!convertOK) {
     name = "signal_process_vertex";
-    writeSignalVertex(evt,retrieveIntAttribute(evt,name),mapIDPart,generatorParameters);
+    writeSignalVertex(evt, retrieveIntAttribute(evt, name), mapIDPart, generatorParameters);
   }
 
   // add the alphaQED
   name = "alphaQED";
-  generatorParameters.setAlphaQED(retrieveDoubleAttribute(evt,name));
+  generatorParameters.setAlphaQED(retrieveDoubleAttribute(evt, name));
 
   // add alphaQCD
   name = "alphaQCD";
-  generatorParameters.setAlphaQCD(retrieveDoubleAttribute(evt,name));
+  generatorParameters.setAlphaQCD(retrieveDoubleAttribute(evt, name));
 
   // add the object to the collection:
   generatorParametersCollection.push_back(generatorParameters);
-  // write the GeneratorEventParameters collection to the frame 
+  // write the GeneratorEventParameters collection to the frame
   eventFrame.put(std::move(generatorParametersCollection), edm4hep::labels::GeneratorEventParameters);
 
   // now the PDFs:
@@ -226,39 +212,41 @@ void WriterEDM4HEP::write_event(const GenEvent &evt)
   //
   // retrieve the pdf information
   HepMC3::ConstGenPdfInfoPtr pdfinfo = evt.pdf_info();
-  if ( pdfinfo ){
+  if (pdfinfo) {
     // store for transfer
-    pdfEDM4HEP.setPartonId({pdfinfo->parton_id[0],pdfinfo->parton_id[1]});
-    pdfEDM4HEP.setX({pdfinfo->x[0],pdfinfo->x[1]});
-    pdfEDM4HEP.setXf({pdfinfo->xf[0],pdfinfo->xf[1]});
-    pdfEDM4HEP.setLhapdfId({pdfinfo->pdf_id[0],pdfinfo->pdf_id[1]});
+    pdfEDM4HEP.setPartonId({pdfinfo->parton_id[0], pdfinfo->parton_id[1]});
+    pdfEDM4HEP.setX({pdfinfo->x[0], pdfinfo->x[1]});
+    pdfEDM4HEP.setXf({pdfinfo->xf[0], pdfinfo->xf[1]});
+    pdfEDM4HEP.setLhapdfId({pdfinfo->pdf_id[0], pdfinfo->pdf_id[1]});
     pdfEDM4HEP.setScale(pdfinfo->scale);
   }
   //
   pdfCollection.push_back(pdfEDM4HEP);
   eventFrame.put(std::move(pdfCollection), edm4hep::labels::GeneratorPdfInfo);
 
-  // LAST ITEM: write the collection of MCParticles to the frame mv empties the collection which we need for processing!!
+  // LAST ITEM: write the collection of MCParticles to the frame mv empties the collection which we need for
+  // processing!!
   eventFrame.put(std::move(particleCollection), edm4hep::labels::MCParticles);
 
   // write the frame to the Writer:
   m_edm4hepWriter.writeFrame(eventFrame, podio::Category::Event);
-
 }
-bool WriterEDM4HEP::writeSignalVertex(const GenEvent& evt, int hepmcVertexID, std::map<unsigned int, edm4hep::MutableMCParticle> &mapHEPMC2EDM4HEP, edm4hep::MutableGeneratorEventParameters& generatorParameters){
+bool WriterEDM4HEP::writeSignalVertex(const GenEvent& evt, int hepmcVertexID,
+                                      std::map<unsigned int, edm4hep::MutableMCParticle>& mapHEPMC2EDM4HEP,
+                                      edm4hep::MutableGeneratorEventParameters& generatorParameters) {
 
   bool convertOK = false;
   // retrieve the vertices
-  for (auto vtx: evt.vertices() ){
+  for (auto vtx : evt.vertices()) {
     // identify the signalvertex via its hepmcID
-    if ( vtx->id() == hepmcVertexID ) {
+    if (vtx->id() == hepmcVertexID) {
       convertOK = true;
       // now insert all incoming particles to the generatorParameters
-      for ( auto part : vtx->particles_in() ){
-	unsigned int hepmcParticleID = part->id();
-	if ( mapHEPMC2EDM4HEP.find(hepmcParticleID) != mapHEPMC2EDM4HEP.end() ) {
-	  generatorParameters.addToSignalVertex(mapHEPMC2EDM4HEP[hepmcParticleID]);
-	}
+      for (auto part : vtx->particles_in()) {
+        unsigned int hepmcParticleID = part->id();
+        if (mapHEPMC2EDM4HEP.find(hepmcParticleID) != mapHEPMC2EDM4HEP.end()) {
+          generatorParameters.addToSignalVertex(mapHEPMC2EDM4HEP[hepmcParticleID]);
+        }
       }
     }
   }
@@ -266,18 +254,18 @@ bool WriterEDM4HEP::writeSignalVertex(const GenEvent& evt, int hepmcVertexID, st
   return convertOK;
 }
 
-double WriterEDM4HEP::retrieveDoubleAttribute(const GenEvent &evt, std::string name) {
+double WriterEDM4HEP::retrieveDoubleAttribute(const GenEvent& evt, std::string name) {
 
   shared_ptr<HepMC3::DoubleAttribute> hepmcPtr = evt.attribute<HepMC3::DoubleAttribute>(name);
-  double result = hepmcPtr?(hepmcPtr->value()):0.0;
+  double result = hepmcPtr ? (hepmcPtr->value()) : 0.0;
 
   return result;
 }
 
-double WriterEDM4HEP::retrieveIntAttribute(const GenEvent &evt, std::string name) {
+double WriterEDM4HEP::retrieveIntAttribute(const GenEvent& evt, std::string name) {
 
   shared_ptr<HepMC3::IntAttribute> hepmcPtr = evt.attribute<HepMC3::IntAttribute>(name);
-  int result = hepmcPtr?(hepmcPtr->value()):0.0;
+  int result = hepmcPtr ? (hepmcPtr->value()) : 0.0;
 
   return result;
 }
@@ -287,23 +275,23 @@ void WriterEDM4HEP::write_run_info() {
   // create the frame
   auto runFrame = podio::Frame();
 
-  // start with the generator information 
+  // start with the generator information
   const std::vector<GenRunInfo::ToolInfo> listOfTools = run_info()->tools();
-  if ( listOfTools.size() == 0 ) {
+  if (listOfTools.size() == 0) {
     std::cout << "WARNING: no tools found, hepmc run_info incomplete" << std::endl;
   }
 
   // the EDM4HEP structure
   std::vector<edm4hep::GeneratorToolInfo> toolInfosVectEDM4HEP;
-  for ( auto hepmcTool:listOfTools){
+  for (auto hepmcTool : listOfTools) {
     edm4hep::GeneratorToolInfo edm4hepTool;
-    edm4hepTool.name    = hepmcTool.name;
+    edm4hepTool.name = hepmcTool.name;
     edm4hepTool.version = hepmcTool.version;
     edm4hepTool.description = hepmcTool.description;
     toolInfosVectEDM4HEP.push_back(edm4hepTool);
   }
   edm4hep::utils::putGenToolInfos(runFrame, toolInfosVectEDM4HEP);
-  
+
   // weight names
   std::vector<std::string> weights = run_info()->weight_names();
 
@@ -312,11 +300,9 @@ void WriterEDM4HEP::write_run_info() {
 
   // write the frame to the Writer:
   m_edm4hepWriter.writeFrame(runFrame, podio::Category::Run);
-
 }
 
-edm4hep::MutableMCParticle WriterEDM4HEP::transformParticle(const ConstGenParticlePtr& hepmcParticle)
-{
+edm4hep::MutableMCParticle WriterEDM4HEP::transformParticle(const ConstGenParticlePtr& hepmcParticle) {
   edm4hep::MutableMCParticle edm_particle;
   edm_particle.setPDG(hepmcParticle->pdg_id());
   edm_particle.setGeneratorStatus(hepmcParticle->status());
@@ -332,31 +318,32 @@ edm4hep::MutableMCParticle WriterEDM4HEP::transformParticle(const ConstGenPartic
   edm_particle.setMass(p.m());
 
   // add spin (particle helicity) information if available
-  //  std::shared_ptr<HepMC3::VectorFloatAttribute> spin = hepmcParticle->attribute<HepMC3::VectorFloatAttribute>("spin");
-  //if (spin) {
+  //  std::shared_ptr<HepMC3::VectorFloatAttribute> spin =
+  //  hepmcParticle->attribute<HepMC3::VectorFloatAttribute>("spin");
+  // if (spin) {
   //   edm4hep::Vector3f hel(spin->value()[0], spin->value()[1], spin->value()[2]);
   //   edm_particle.setSpin(hel);
   //}
   std::shared_ptr<HepMC3::DoubleAttribute> thetaPtr = hepmcParticle->attribute<HepMC3::DoubleAttribute>("theta");
-  std::shared_ptr<HepMC3::DoubleAttribute> phiPtr   = hepmcParticle->attribute<HepMC3::DoubleAttribute>("phi");
-  if ( thetaPtr && phiPtr ){
+  std::shared_ptr<HepMC3::DoubleAttribute> phiPtr = hepmcParticle->attribute<HepMC3::DoubleAttribute>("phi");
+  if (thetaPtr && phiPtr) {
     float theta = static_cast<float>(thetaPtr->value());
-    float phi   = static_cast<float>(phiPtr->value());
-    edm4hep::Vector3f hel(cos(phi)*cos(theta), sin(phi)*cos(theta), sin(theta));
+    float phi = static_cast<float>(phiPtr->value());
+    edm4hep::Vector3f hel(cos(phi) * cos(theta), sin(phi) * cos(theta), sin(theta));
     edm_particle.setSpin(hel);
   }
 
   // convert production vertex info and time info:
   auto prodVtx = hepmcParticle->production_vertex();
-  if ( prodVtx!=nullptr ) {
+  if (prodVtx != nullptr) {
     auto& pos = prodVtx->position();
     edm_particle.setVertex(edm4hep::Vector3d(pos.x(), pos.y(), pos.z()));
     edm_particle.setTime(pos.t());
   }
 
-  // convert the decay vertex (if present) 
+  // convert the decay vertex (if present)
   auto endpointVtx = hepmcParticle->end_vertex();
-  if ( endpointVtx!=nullptr ) {
+  if (endpointVtx != nullptr) {
     auto& pos = endpointVtx->position();
     edm_particle.setEndpoint(edm4hep::Vector3d(pos.x(), pos.y(), pos.z()));
   }
@@ -364,13 +351,9 @@ edm4hep::MutableMCParticle WriterEDM4HEP::transformParticle(const ConstGenPartic
   return edm_particle;
 }
 
-bool WriterEDM4HEP::failed()
-{
-  return false;
-}
-void WriterEDM4HEP::close()
-{
+bool WriterEDM4HEP::failed() { return false; }
+void WriterEDM4HEP::close() {
   m_edm4hepWriter.finish();
   m_edm4hepWriterClosed = true;
 }
-}
+} // namespace HepMC3

--- a/k4GeneratorsConfig/src/WriterEDM4HEP.h
+++ b/k4GeneratorsConfig/src/WriterEDM4HEP.h
@@ -14,82 +14,75 @@
 ///
 /// @ingroup IO
 ///
-#include "HepMC3/Writer.h"
 #include "HepMC3/GenEvent.h"
 #include "HepMC3/GenRunInfo.h"
-#include <string>
+#include "HepMC3/Writer.h"
 #include <fstream>
+#include <string>
 
-#include "edm4hep/MutableGeneratorEventParameters.h"
 #include "edm4hep/MCParticleCollection.h"
+#include "edm4hep/MutableGeneratorEventParameters.h"
 #include "podio/ROOTWriter.h"
 
-namespace HepMC3
-{
-  
-  class WriterEDM4HEP : public Writer
-  {
-  public:
-    
-    /// @brief Constructor
-    /// @warning If file already exists, it will be cleared before writing
-    WriterEDM4HEP(const std::string& filename,
-		  std::shared_ptr<GenRunInfo> run = std::shared_ptr<GenRunInfo>());
-    
-    /// @brief Constructor from ostream
-    WriterEDM4HEP(std::ostream& stream,
-		  std::shared_ptr<GenRunInfo> run = std::shared_ptr<GenRunInfo>());
-    /// @brief Constructor from temp ostream
-    WriterEDM4HEP(std::shared_ptr<std::ostream> s_stream,
-		  std::shared_ptr<GenRunInfo> run = std::shared_ptr<GenRunInfo>());
-    
-    /// @brief Destructor
-    ~WriterEDM4HEP();
-    
-    /// @brief Write event to file
-    ///
-    /// @param[in] evt Event to be serialized
-    void write_event(const GenEvent& evt)  override;
-    
-    /// @brief Write the GenRunInfo object to file.
-    void write_run_info();
-    
-    bool failed()  override;
-    
-    /// @brief Close file stream
-    void close()  override;
-    
-  private:
-    
-    /// @brief Write particle
-    ///
-    /// Helper routine for writing single particle to file
-    edm4hep::MutableMCParticle transformParticle(const ConstGenParticlePtr& p);
-    
-    /// Helper routine to translate the HepMC Vertex ID
-    bool writeSignalVertex(const GenEvent& evt, int hepmcVertex,std::map<unsigned int, edm4hep::MutableMCParticle> &mapHEPMC2PODIO, edm4hep::MutableGeneratorEventParameters &genParams);
-    
-    /// retrieve the attribute of type double
-    double retrieveDoubleAttribute(const GenEvent& evt, std::string name);
-    
-    /// retrieve the attribute of type int
-    double retrieveIntAttribute(const GenEvent& evt, std::string name);
-    
-    /// @}
-    
-  private:
-    
-    std::ofstream m_file; //!< Output file
-    std::shared_ptr<std::ostream> m_shared_stream;///< Output temp. stream
-    std::ostream* m_stream; //!< Output stream
-    unsigned long m_particle_counter; //!< Used to set bar codes
-    
-    bool m_edm4hepWriterClosed;
-    podio::ROOTWriter m_edm4hepWriter;
-    
-  };
-  
-  
+namespace HepMC3 {
+
+class WriterEDM4HEP : public Writer {
+public:
+  /// @brief Constructor
+  /// @warning If file already exists, it will be cleared before writing
+  WriterEDM4HEP(const std::string& filename, std::shared_ptr<GenRunInfo> run = std::shared_ptr<GenRunInfo>());
+
+  /// @brief Constructor from ostream
+  WriterEDM4HEP(std::ostream& stream, std::shared_ptr<GenRunInfo> run = std::shared_ptr<GenRunInfo>());
+  /// @brief Constructor from temp ostream
+  WriterEDM4HEP(std::shared_ptr<std::ostream> s_stream,
+                std::shared_ptr<GenRunInfo> run = std::shared_ptr<GenRunInfo>());
+
+  /// @brief Destructor
+  ~WriterEDM4HEP();
+
+  /// @brief Write event to file
+  ///
+  /// @param[in] evt Event to be serialized
+  void write_event(const GenEvent& evt) override;
+
+  /// @brief Write the GenRunInfo object to file.
+  void write_run_info();
+
+  bool failed() override;
+
+  /// @brief Close file stream
+  void close() override;
+
+private:
+  /// @brief Write particle
+  ///
+  /// Helper routine for writing single particle to file
+  edm4hep::MutableMCParticle transformParticle(const ConstGenParticlePtr& p);
+
+  /// Helper routine to translate the HepMC Vertex ID
+  bool writeSignalVertex(const GenEvent& evt, int hepmcVertex,
+                         std::map<unsigned int, edm4hep::MutableMCParticle>& mapHEPMC2PODIO,
+                         edm4hep::MutableGeneratorEventParameters& genParams);
+
+  /// retrieve the attribute of type double
+  double retrieveDoubleAttribute(const GenEvent& evt, std::string name);
+
+  /// retrieve the attribute of type int
+  double retrieveIntAttribute(const GenEvent& evt, std::string name);
+
+  /// @}
+
+private:
+  std::ofstream m_file;                          //!< Output file
+  std::shared_ptr<std::ostream> m_shared_stream; ///< Output temp. stream
+  std::ostream* m_stream;                        //!< Output stream
+  unsigned long m_particle_counter;              //!< Used to set bar codes
+
+  bool m_edm4hepWriterClosed;
+  podio::ROOTWriter m_edm4hepWriter;
+};
+
 } // namespace HepMC3
 
 #endif

--- a/k4GeneratorsConfig/src/convertHepMC2EDM4HEP.cxx
+++ b/k4GeneratorsConfig/src/convertHepMC2EDM4HEP.cxx
@@ -6,26 +6,26 @@
 /// @example convert_example.cc
 /// @brief Utility to convert between different types of event records
 ///
-#include "HepMC3/Print.h"
 #include "HepMC3/GenEvent.h"
+#include "HepMC3/Print.h"
 #include "HepMC3/Reader.h"
-#include "HepMC3/ReaderAsciiHepMC2.h"
-#include "HepMC3/WriterAsciiHepMC2.h"
 #include "HepMC3/ReaderAscii.h"
-#include "HepMC3/WriterAscii.h"
-#include "HepMC3/WriterHEPEVT.h"
-#include "HepMC3/WriterPlugin.h"
+#include "HepMC3/ReaderAsciiHepMC2.h"
+#include "HepMC3/ReaderFactory.h"
 #include "HepMC3/ReaderHEPEVT.h"
 #include "HepMC3/ReaderLHEF.h"
 #include "HepMC3/ReaderPlugin.h"
-#include "HepMC3/ReaderFactory.h"
+#include "HepMC3/WriterAscii.h"
+#include "HepMC3/WriterAsciiHepMC2.h"
+#include "HepMC3/WriterHEPEVT.h"
+#include "HepMC3/WriterPlugin.h"
 
 #include "WriterEDM4HEP.h"
 
 #ifdef HEPMC3_ROOTIO
 #include "HepMC3/ReaderRoot.h"
-#include "HepMC3/WriterRoot.h"
 #include "HepMC3/ReaderRootTree.h"
+#include "HepMC3/WriterRoot.h"
 #include "HepMC3/WriterRootTree.h"
 #endif
 #if HEPMC3_USE_COMPRESSION
@@ -40,281 +40,300 @@
 /* Extension example*/
 #ifdef HEPMCCONVERT_EXTENSION_ROOTTREEOPAL
 #ifndef HEPMC3_ROOTIO
-#warning "HEPMCCONVERT_EXTENSION_ROOTTREEOPAL requires  compilation with of HepMC with ROOT, i.e. HEPMC3_ROOTIO.This extension will be disabled."
+#warning                                                                                                               \
+    "HEPMCCONVERT_EXTENSION_ROOTTREEOPAL requires  compilation with of HepMC with ROOT, i.e. HEPMC3_ROOTIO.This extension will be disabled."
 #undef HEPMCCONVERT_EXTENSION_ROOTTREEOPAL
 #else
 #include "WriterRootTreeOPAL.h"
 #endif
 #endif
 
-
 #include "cmdline.h"
 using namespace HepMC3;
-enum formats {autodetect, hepmc2, hepmc3, EDM4HEP, hpe,root, treeroot, treerootopal, lhef, dump, dot,  plugin, none, proto};
+enum formats {
+  autodetect,
+  hepmc2,
+  hepmc3,
+  EDM4HEP,
+  hpe,
+  root,
+  treeroot,
+  treerootopal,
+  lhef,
+  dump,
+  dot,
+  plugin,
+  none,
+  proto
+};
 
 template <class T>
 std::shared_ptr<Reader> get_input_file(const char* name, const bool input_is_stdin, const bool use_compression) {
-    std::string n(name);
-#if  HEPMC3_USE_COMPRESSION
-    if (use_compression) {
-        return (input_is_stdin?std::make_shared<ReaderGZ<T> >(std::cin):std::make_shared<ReaderGZ<T> >(n));
-    }
+  std::string n(name);
+#if HEPMC3_USE_COMPRESSION
+  if (use_compression) {
+    return (input_is_stdin ? std::make_shared<ReaderGZ<T>>(std::cin) : std::make_shared<ReaderGZ<T>>(n));
+  }
 #endif
-    return (input_is_stdin?std::make_shared<T>(std::cin):std::make_shared<T>(n));
+  return (input_is_stdin ? std::make_shared<T>(std::cin) : std::make_shared<T>(n));
 }
 template <class T>
 std::shared_ptr<Writer> get_output_file(const char* name, const char* use_compression) {
-    std::string n(name);
+  std::string n(name);
 #if HEPMC3_USE_COMPRESSION
-    if (std::string(use_compression) == "z" )  return std::make_shared< WriterGZ<T,Compression::z> >(n);
-    if (std::string(use_compression) == "lzma" )  return std::make_shared< WriterGZ<T,Compression::lzma> >(n);
-    if (std::string(use_compression) == "bz2" )  return std::make_shared< WriterGZ<T,Compression::bz2> >(n);
+  if (std::string(use_compression) == "z")
+    return std::make_shared<WriterGZ<T, Compression::z>>(n);
+  if (std::string(use_compression) == "lzma")
+    return std::make_shared<WriterGZ<T, Compression::lzma>>(n);
+  if (std::string(use_compression) == "bz2")
+    return std::make_shared<WriterGZ<T, Compression::bz2>>(n);
 #endif
-    return std::make_shared<T>(n);
+  return std::make_shared<T>(n);
 }
 
-int main(int argc, char** argv)
-{
-    gengetopt_args_info ai;
-    if (cmdline_parser (argc, argv, &ai) != 0) {
-        exit(1);
+int main(int argc, char** argv) {
+  gengetopt_args_info ai;
+  if (cmdline_parser(argc, argv, &ai) != 0) {
+    exit(1);
+  }
+  if (!((ai.inputs_num == 2 && (std::string(ai.output_format_arg) != "none")) ||
+        (ai.inputs_num == 1 && (std::string(ai.output_format_arg) == "none")))) {
+    printf(
+        "Exactly two arguments are requred: the name of input and output files if the output format in not \"none\"\n");
+    printf("In case the output format is \"none\" exactly one argument should be given: the name of input file.\n");
+    exit(1);
+  }
+  std::map<std::string, formats> format_map;
+  format_map.insert(std::pair<std::string, formats>("auto", autodetect));
+  format_map.insert(std::pair<std::string, formats>("hepmc2", hepmc2));
+  format_map.insert(std::pair<std::string, formats>("hepmc3", hepmc3));
+  format_map.insert(std::pair<std::string, formats>("edm4hep", EDM4HEP));
+  format_map.insert(std::pair<std::string, formats>("hpe", hpe));
+  format_map.insert(std::pair<std::string, formats>("root", root));
+  format_map.insert(std::pair<std::string, formats>("treeroot", treeroot));
+  format_map.insert(std::pair<std::string, formats>("treerootopal", treerootopal));
+  format_map.insert(std::pair<std::string, formats>("lhef", lhef));
+  format_map.insert(std::pair<std::string, formats>("dump", dump));
+  format_map.insert(std::pair<std::string, formats>("dot", dot));
+  format_map.insert(std::pair<std::string, formats>("plugin", plugin));
+  format_map.insert(std::pair<std::string, formats>("none", none));
+  format_map.insert(std::pair<std::string, formats>("proto", proto));
+  std::map<std::string, std::string> options;
+  for (size_t i = 0; i < ai.extensions_given; i++) {
+    std::string optarg(ai.extensions_arg[i]);
+    size_t pos = optarg.find_first_of('=');
+    if (pos < optarg.length()) {
+      options[std::string(optarg, 0, pos)] = std::string(optarg, pos + 1, optarg.length());
     }
-    if ( !( ( ai.inputs_num == 2 && ( std::string(ai.output_format_arg) !=  "none" )) || ( ai.inputs_num == 1 && ( std::string(ai.output_format_arg) ==  "none") ) )   )
-    {
-        printf("Exactly two arguments are requred: the name of input and output files if the output format in not \"none\"\n");
-        printf("In case the output format is \"none\" exactly one argument should be given: the name of input file.\n");
-        exit(1);
-    }
-    std::map<std::string,formats> format_map;
-    format_map.insert(std::pair<std::string,formats> ( "auto", autodetect ));
-    format_map.insert(std::pair<std::string,formats> ( "hepmc2", hepmc2 ));
-    format_map.insert(std::pair<std::string,formats> ( "hepmc3", hepmc3 ));
-    format_map.insert(std::pair<std::string,formats> ( "edm4hep", EDM4HEP ));
-    format_map.insert(std::pair<std::string,formats> ( "hpe", hpe  ));
-    format_map.insert(std::pair<std::string,formats> ( "root", root ));
-    format_map.insert(std::pair<std::string,formats> ( "treeroot", treeroot ));
-    format_map.insert(std::pair<std::string,formats> ( "treerootopal", treerootopal ));
-    format_map.insert(std::pair<std::string,formats> ( "lhef", lhef ));
-    format_map.insert(std::pair<std::string,formats> ( "dump", dump ));
-    format_map.insert(std::pair<std::string,formats> ( "dot", dot ));
-    format_map.insert(std::pair<std::string,formats> ( "plugin", plugin ));
-    format_map.insert(std::pair<std::string,formats> ( "none", none ));
-    format_map.insert(std::pair<std::string,formats> ( "proto", proto ));
-    std::map<std::string, std::string> options;
-    for (size_t i=0; i<ai.extensions_given; i++)
-    {
-        std::string optarg(ai.extensions_arg[i]);
-        size_t pos = optarg.find_first_of('=');
-        if ( pos < optarg.length() ) {
-            options[std::string(optarg,0,pos)] = std::string(optarg, pos+1, optarg.length());
-        }
-    }
-    long int  events_parsed = 0;
-    long int  events_limit = ai.events_limit_arg;
-    long int  first_event_number = ai.first_event_number_arg;
-    long int  last_event_number = ai.last_event_number_arg;
-    long int  print_each_events_parsed = ai.print_every_events_parsed_arg;
-    std::string InputPluginLibrary;
-    std::string InputPluginName;
+  }
+  long int events_parsed = 0;
+  long int events_limit = ai.events_limit_arg;
+  long int first_event_number = ai.first_event_number_arg;
+  long int last_event_number = ai.last_event_number_arg;
+  long int print_each_events_parsed = ai.print_every_events_parsed_arg;
+  std::string InputPluginLibrary;
+  std::string InputPluginName;
 
-    std::string OutputPluginLibrary;
-    std::string OutputPluginName;
+  std::string OutputPluginLibrary;
+  std::string OutputPluginName;
 
-    std::shared_ptr<Reader>      input_file;
-    bool input_is_stdin = (std::string(ai.inputs[0]) == std::string("-"));
-    if (input_is_stdin) std::ios_base::sync_with_stdio(false);
-    bool ignore_writer = false;
-    switch (format_map.at(std::string(ai.input_format_arg)))
-    {
-    case autodetect:
-        input_file = (input_is_stdin?deduce_reader(std::cin):deduce_reader(ai.inputs[0]));
-        if (!input_file)
-        {
-            input_is_stdin?printf("Input format  detection for std input has failed\n"):printf("Input format  detection for file %s has failed\n",ai.inputs[0]);
-            exit(2);
-        }
-        break;
-    case hepmc2:
-        input_file = get_input_file<ReaderAsciiHepMC2>(ai.inputs[0], input_is_stdin, ai.compressed_input_flag);
-        break;
-    case hepmc3:
-        input_file = get_input_file<ReaderAscii>(ai.inputs[0], input_is_stdin, ai.compressed_input_flag);
-        break;
-    case EDM4HEP:
-        printf("Input format %s  is not supported\n", ai.input_format_arg);
-        exit(2);
-        break;
-    case hpe:
-        input_file = get_input_file<ReaderHEPEVT>(ai.inputs[0], input_is_stdin,ai.compressed_input_flag);
-        break;
-    case lhef:
-        input_file = get_input_file<ReaderLHEF>(ai.inputs[0], input_is_stdin, ai.compressed_input_flag);
-        break;
-    case treeroot:
-#ifdef HEPMC3_ROOTIO
-        input_file = std::make_shared<ReaderRootTree>(ai.inputs[0]);
-        break;
-#else
-        printf("Input format %s  is not supported\n", ai.input_format_arg);
-        exit(2);
-#endif
-    case root:
-#ifdef HEPMC3_ROOTIO
-        input_file = std::make_shared<ReaderRoot>(ai.inputs[0]);
-        break;
-#else
-        printf("Input format %s  is not supported\n", ai.input_format_arg);
-        exit(2);
-#endif
-    case proto:
-#ifdef HEPMC3_PROTOBUFIO
-        input_file = std::make_shared<Readerprotobuf>(ai.inputs[0]);
-        break;
-#else
-        printf("Input format %s  is not supported\n", ai.input_format_arg);
-        exit(2);
-#endif
-    case plugin:
-        if (options.find("InputPluginLibrary") == options.end())         {
-            printf("InputPluginLibrary option required\n");
-            exit(2);
-        }
-        else InputPluginLibrary = options.at("InputPluginLibrary");
-        if (options.find("InputPluginName") == options.end())            {
-            printf("InputPluginName option required\n");
-            exit(2);
-        }
-        else InputPluginName = options.at("InputPluginName");
-        input_file = std::make_shared<ReaderPlugin>(std::string(ai.inputs[0]), InputPluginLibrary, InputPluginName);
-        if (input_file->failed()) {
-            printf("Plugin initialization failed\n");
-            exit(2);
-        }
-        break;
-    default:
-        printf("Input format %s  is not known\n", ai.input_format_arg);
-        exit(2);
-        break;
+  std::shared_ptr<Reader> input_file;
+  bool input_is_stdin = (std::string(ai.inputs[0]) == std::string("-"));
+  if (input_is_stdin)
+    std::ios_base::sync_with_stdio(false);
+  bool ignore_writer = false;
+  switch (format_map.at(std::string(ai.input_format_arg))) {
+  case autodetect:
+    input_file = (input_is_stdin ? deduce_reader(std::cin) : deduce_reader(ai.inputs[0]));
+    if (!input_file) {
+      input_is_stdin ? printf("Input format  detection for std input has failed\n")
+                     : printf("Input format  detection for file %s has failed\n", ai.inputs[0]);
+      exit(2);
     }
-    std::shared_ptr<Writer>      output_file;
-    switch (format_map.at(std::string(ai.output_format_arg)))
-    {
-    case hepmc2:
-        output_file = get_output_file<WriterAsciiHepMC2>(ai.inputs[1], ai.compressed_output_arg);
-        break;
-    case hepmc3:
-        output_file = get_output_file<WriterAscii>(ai.inputs[1], ai.compressed_output_arg);
-        break;
-    case EDM4HEP:
-        output_file = get_output_file<WriterEDM4HEP>(ai.inputs[1], ai.compressed_output_arg);
-        break;
-    case hpe:
-        output_file = get_output_file<WriterHEPEVT>(ai.inputs[1], ai.compressed_output_arg);
-        break;
-    case root:
+    break;
+  case hepmc2:
+    input_file = get_input_file<ReaderAsciiHepMC2>(ai.inputs[0], input_is_stdin, ai.compressed_input_flag);
+    break;
+  case hepmc3:
+    input_file = get_input_file<ReaderAscii>(ai.inputs[0], input_is_stdin, ai.compressed_input_flag);
+    break;
+  case EDM4HEP:
+    printf("Input format %s  is not supported\n", ai.input_format_arg);
+    exit(2);
+    break;
+  case hpe:
+    input_file = get_input_file<ReaderHEPEVT>(ai.inputs[0], input_is_stdin, ai.compressed_input_flag);
+    break;
+  case lhef:
+    input_file = get_input_file<ReaderLHEF>(ai.inputs[0], input_is_stdin, ai.compressed_input_flag);
+    break;
+  case treeroot:
 #ifdef HEPMC3_ROOTIO
-        output_file = std::make_shared<WriterRoot>(ai.inputs[1]);
-        break;
+    input_file = std::make_shared<ReaderRootTree>(ai.inputs[0]);
+    break;
 #else
-        printf("Output format %s  is not supported\n", ai.output_format_arg);
-        exit(2);
+    printf("Input format %s  is not supported\n", ai.input_format_arg);
+    exit(2);
 #endif
-    case proto:
+  case root:
+#ifdef HEPMC3_ROOTIO
+    input_file = std::make_shared<ReaderRoot>(ai.inputs[0]);
+    break;
+#else
+    printf("Input format %s  is not supported\n", ai.input_format_arg);
+    exit(2);
+#endif
+  case proto:
 #ifdef HEPMC3_PROTOBUFIO
-        output_file = std::make_shared<Writerprotobuf>(ai.inputs[1]);
-        break;
+    input_file = std::make_shared<Readerprotobuf>(ai.inputs[0]);
+    break;
 #else
-        printf("Output format %s  is not supported\n", ai.output_format_arg);
-        exit(2);
+    printf("Input format %s  is not supported\n", ai.input_format_arg);
+    exit(2);
 #endif
-    case treeroot:
+  case plugin:
+    if (options.find("InputPluginLibrary") == options.end()) {
+      printf("InputPluginLibrary option required\n");
+      exit(2);
+    } else
+      InputPluginLibrary = options.at("InputPluginLibrary");
+    if (options.find("InputPluginName") == options.end()) {
+      printf("InputPluginName option required\n");
+      exit(2);
+    } else
+      InputPluginName = options.at("InputPluginName");
+    input_file = std::make_shared<ReaderPlugin>(std::string(ai.inputs[0]), InputPluginLibrary, InputPluginName);
+    if (input_file->failed()) {
+      printf("Plugin initialization failed\n");
+      exit(2);
+    }
+    break;
+  default:
+    printf("Input format %s  is not known\n", ai.input_format_arg);
+    exit(2);
+    break;
+  }
+  std::shared_ptr<Writer> output_file;
+  switch (format_map.at(std::string(ai.output_format_arg))) {
+  case hepmc2:
+    output_file = get_output_file<WriterAsciiHepMC2>(ai.inputs[1], ai.compressed_output_arg);
+    break;
+  case hepmc3:
+    output_file = get_output_file<WriterAscii>(ai.inputs[1], ai.compressed_output_arg);
+    break;
+  case EDM4HEP:
+    output_file = get_output_file<WriterEDM4HEP>(ai.inputs[1], ai.compressed_output_arg);
+    break;
+  case hpe:
+    output_file = get_output_file<WriterHEPEVT>(ai.inputs[1], ai.compressed_output_arg);
+    break;
+  case root:
 #ifdef HEPMC3_ROOTIO
-        output_file = std::make_shared<WriterRootTree>(ai.inputs[1]);
-        break;
+    output_file = std::make_shared<WriterRoot>(ai.inputs[1]);
+    break;
 #else
-        printf("Output format %s  is not supported\n",ai.output_format_arg);
-        exit(2);
+    printf("Output format %s  is not supported\n", ai.output_format_arg);
+    exit(2);
 #endif
-    /* Extension example*/
-    case treerootopal:
+  case proto:
+#ifdef HEPMC3_PROTOBUFIO
+    output_file = std::make_shared<Writerprotobuf>(ai.inputs[1]);
+    break;
+#else
+    printf("Output format %s  is not supported\n", ai.output_format_arg);
+    exit(2);
+#endif
+  case treeroot:
+#ifdef HEPMC3_ROOTIO
+    output_file = std::make_shared<WriterRootTree>(ai.inputs[1]);
+    break;
+#else
+    printf("Output format %s  is not supported\n", ai.output_format_arg);
+    exit(2);
+#endif
+  /* Extension example*/
+  case treerootopal:
 #ifdef HEPMCCONVERT_EXTENSION_ROOTTREEOPAL
-        output_file = std::make_shared<WriterRootTreeOPAL>(ai.inputs[1]);
-        (std::dynamic_pointer_cast<WriterRootTreeOPAL>(output_file))->init_branches();
-        if (options.find("Run") != options.end()) (std::dynamic_pointer_cast<WriterRootTreeOPAL>(output_file))->set_run_number(std::atoi(options.at("Run").c_str()));
-        break;
+    output_file = std::make_shared<WriterRootTreeOPAL>(ai.inputs[1]);
+    (std::dynamic_pointer_cast<WriterRootTreeOPAL>(output_file))->init_branches();
+    if (options.find("Run") != options.end())
+      (std::dynamic_pointer_cast<WriterRootTreeOPAL>(output_file))
+          ->set_run_number(std::atoi(options.at("Run").c_str()));
+    break;
 #else
-        printf("Output format %s  is not supported\n",ai.output_format_arg);
-        exit(2);
-        break;
+    printf("Output format %s  is not supported\n", ai.output_format_arg);
+    exit(2);
+    break;
 #endif
-    case plugin:
-        if (options.find("OutputPluginLibrary") == options.end())         {
-            printf("OutputPluginLibrary option required, e.g. OutputPluginLibrary=libAnalysis.so\n");
-            exit(2);
-        }
-        else OutputPluginLibrary = options.at("OutputPluginLibrary");
-        if (options.find("OutputPluginName") == options.end())            {
-            printf("OutputPluginName option required, e.g. OutputPluginName=newAnalysisExamplefile\n");
-            exit(2);
-        }
-        else OutputPluginName = options.at("OutputPluginName");
-        output_file = std::make_shared<WriterPlugin>(std::string(ai.inputs[1]), OutputPluginLibrary, OutputPluginName);
-        if (output_file->failed()) {
-            printf("Plugin initialization failed\n");
-            exit(2);
-        }
-        break;
-    case dump:
-        output_file = nullptr;
-        break;
-    case none:
-        output_file = nullptr;
-        ignore_writer = true;
-        break;
-    default:
-        printf("Output format %s  is not known\n", ai.output_format_arg);
-        exit(2);
-        break;
+  case plugin:
+    if (options.find("OutputPluginLibrary") == options.end()) {
+      printf("OutputPluginLibrary option required, e.g. OutputPluginLibrary=libAnalysis.so\n");
+      exit(2);
+    } else
+      OutputPluginLibrary = options.at("OutputPluginLibrary");
+    if (options.find("OutputPluginName") == options.end()) {
+      printf("OutputPluginName option required, e.g. OutputPluginName=newAnalysisExamplefile\n");
+      exit(2);
+    } else
+      OutputPluginName = options.at("OutputPluginName");
+    output_file = std::make_shared<WriterPlugin>(std::string(ai.inputs[1]), OutputPluginLibrary, OutputPluginName);
+    if (output_file->failed()) {
+      printf("Plugin initialization failed\n");
+      exit(2);
     }
-    while( !input_file->failed() )
-    {
-        GenEvent evt(Units::GEV, Units::MM);
-        bool res_read = input_file->read_event(evt);
+    break;
+  case dump:
+    output_file = nullptr;
+    break;
+  case none:
+    output_file = nullptr;
+    ignore_writer = true;
+    break;
+  default:
+    printf("Output format %s  is not known\n", ai.output_format_arg);
+    exit(2);
+    break;
+  }
+  while (!input_file->failed()) {
+    GenEvent evt(Units::GEV, Units::MM);
+    bool res_read = input_file->read_event(evt);
 
-        if( input_file->failed() )  {
-            printf("End of file reached. Exit.\n");
-            break;
-        }
-        if ( !res_read && ai.strict_read_arg) {
-            printf("Broken event. Exit.\n");
-            exit(3);
-        }
-        if (evt.event_number() < first_event_number) continue;
-        if (evt.event_number() > last_event_number) continue;
-        evt.set_run_info(input_file->run_info());
-        //Note the difference between ROOT and Ascii readers. The former read GenRunInfo before first event and the later at the same time as first event.
-        if (!ignore_writer)
-        {
-            if (output_file)
-            {
-                output_file->write_event(evt);
-            }
-            else
-            {
-                Print::content(evt);
-            }
-        }
-        evt.clear();
-        ++events_parsed;
-        if( events_parsed%print_each_events_parsed == 0 ) printf("Events parsed: %li\n", events_parsed);
-        if( events_parsed >= events_limit ) {
-            printf("Event limit reached:->events_parsed(%li) >= events_limit(%li)<-. Exit.\n", events_parsed, events_limit);
-            break;
-        }
+    if (input_file->failed()) {
+      printf("End of file reached. Exit.\n");
+      break;
     }
+    if (!res_read && ai.strict_read_arg) {
+      printf("Broken event. Exit.\n");
+      exit(3);
+    }
+    if (evt.event_number() < first_event_number)
+      continue;
+    if (evt.event_number() > last_event_number)
+      continue;
+    evt.set_run_info(input_file->run_info());
+    // Note the difference between ROOT and Ascii readers. The former read GenRunInfo before first event and the later
+    // at the same time as first event.
+    if (!ignore_writer) {
+      if (output_file) {
+        output_file->write_event(evt);
+      } else {
+        Print::content(evt);
+      }
+    }
+    evt.clear();
+    ++events_parsed;
+    if (events_parsed % print_each_events_parsed == 0)
+      printf("Events parsed: %li\n", events_parsed);
+    if (events_parsed >= events_limit) {
+      printf("Event limit reached:->events_parsed(%li) >= events_limit(%li)<-. Exit.\n", events_parsed, events_limit);
+      break;
+    }
+  }
 
-    if (input_file)   input_file->close();
-    if (output_file)  output_file->close();
-    cmdline_parser_free(&ai);
-    return EXIT_SUCCESS;
+  if (input_file)
+    input_file->close();
+  if (output_file)
+    output_file->close();
+  cmdline_parser_free(&ai);
+  return EXIT_SUCCESS;
 }

--- a/k4GeneratorsConfig/src/key4HEPAnalysis.cxx
+++ b/k4GeneratorsConfig/src/key4HEPAnalysis.cxx
@@ -1,30 +1,29 @@
 // File to read EDM4HEP output and extract the cross sections
-#include <iostream>
 #include <fstream>
+#include <iostream>
 #include <unistd.h>
 
 #include "TFile.h"
 #include "TH1D.h"
 
-#include "podio/ROOTReader.h"
-#include "podio/Frame.h"
 #include "edm4hep/Constants.h"
 #include "edm4hep/GeneratorEventParametersCollection.h"
 #include "edm4hep/GeneratorToolInfo.h"
 #include "edm4hep/MCParticleCollection.h"
+#include "podio/Frame.h"
+#include "podio/ROOTReader.h"
 
 #include "edm4hep/utils/kinematics.h"
 
 //
-int main(int argc, char** argv)
-{
+int main(int argc, char** argv) {
 
-  std::string inFileName="events.edm4hep";
-  std::string outFileName="histograms.root";
-  std::string particles="11,-11";
+  std::string inFileName = "events.edm4hep";
+  std::string outFileName = "histograms.root";
+  std::string particles = "11,-11";
   int c;
-  while ((c = getopt (argc, argv, "hp:i:o:")) != -1)
-    switch (c){
+  while ((c = getopt(argc, argv, "hp:i:o:")) != -1)
+    switch (c) {
     case 'o':
       outFileName = optarg;
       break;
@@ -39,7 +38,8 @@ int main(int argc, char** argv)
       std::cout << "-h: print this help" << std::endl;
       std::cout << "-i filename: input filename" << std::endl;
       std::cout << "-o filename: output filename" << std::endl;
-      std::cout << "-p pdgID1,pddID2,....: comma separated list of the pdg ids in the finalstate to be analyzed" << std::endl;
+      std::cout << "-p pdgID1,pddID2,....: comma separated list of the pdg ids in the finalstate to be analyzed"
+                << std::endl;
       exit(0);
     default:
       exit(0);
@@ -55,66 +55,72 @@ int main(int argc, char** argv)
   }
 
   std::cout << "key4HEPAnalysis:" << std::endl
-	    << "Input  file         " << inFileName << std::endl
-	    << "Output file        : " << outFileName << std::endl;
-  for (unsigned int i=0; i<particlesList.size(); i++){
+            << "Input  file         " << inFileName << std::endl
+            << "Output file        : " << outFileName << std::endl;
+  for (unsigned int i = 0; i < particlesList.size(); i++) {
     std::cout << "pdg particle " << i << " : " << particlesList[i] << std::endl;
   }
 
   // open the edm4hep file
-  podio::ROOTReader *reader;
+  podio::ROOTReader* reader;
   reader = new podio::ROOTReader();
   reader->openFile(inFileName);
 
   // retrieve the RunInfo for the weight names, there should only be 1 entry per Run
-  if ( reader->getEntries(podio::Category::Run) == 0 ){
+  if (reader->getEntries(podio::Category::Run) == 0) {
     exit(0);
   }
 
   // decode the tool infor from Run
   auto runinfo = podio::Frame(reader->readNextEntry(podio::Category::Run));
   auto toolInfos = edm4hep::utils::getGenToolInfos(runinfo);
-  if ( toolInfos.size() > 0 ){
+  if (toolInfos.size() > 0) {
     std::cout << "analyze2f the tool " << toolInfos[0].name << std::endl;
-  }
-  else {
+  } else {
     std::cout << "k4GeneratorsConfig::Warning: ToolInfos not available" << std::endl;
   }
 
   // retrieve the cross section for the last event if not possible it's not valid
-  if ( reader->getEntries(podio::Category::Event) == 0 ){
+  if (reader->getEntries(podio::Category::Event) == 0) {
     exit(0);
   }
 
   // get the frame parameters
   auto event = podio::Frame(reader->readNextEntry(podio::Category::Event));
-  const edm4hep::GeneratorEventParametersCollection &genParametersCollection = event.get<edm4hep::GeneratorEventParametersCollection>(edm4hep::labels::GeneratorEventParameters);
-  if ( genParametersCollection.size() == 0 ) exit(0);
+  const edm4hep::GeneratorEventParametersCollection& genParametersCollection =
+      event.get<edm4hep::GeneratorEventParametersCollection>(edm4hep::labels::GeneratorEventParameters);
+  if (genParametersCollection.size() == 0)
+    exit(0);
   edm4hep::GeneratorEventParameters genParameters = genParametersCollection[0];
-  
+
   // decode sqrts
   double sqrts = genParameters.getSqrts();
 
   // histogram reservations
   // prepare some histograms
-  ss.clear(); ss.str("");
+  ss.clear();
+  ss.str("");
   ss << "Particle PDGID = " << particlesList[0] << " cos(theta)";
-  TH1D* pdgAcostheta = new TH1D("pdgacostheta",ss.str().c_str(),200, -1.,1.);
-  ss.clear(); ss.str("");
+  TH1D* pdgAcostheta = new TH1D("pdgacostheta", ss.str().c_str(), 200, -1., 1.);
+  ss.clear();
+  ss.str("");
   ss << "Particle PDGID = " << particlesList[1] << " cos(theta)";
-  TH1D* pdgBcostheta = new TH1D("pdgbcostheta",ss.str().c_str(),200, -1.,1.);
+  TH1D* pdgBcostheta = new TH1D("pdgbcostheta", ss.str().c_str(), 200, -1., 1.);
 
-  ss.clear(); ss.str("");
+  ss.clear();
+  ss.str("");
   ss << "Invariant Mass(" << particlesList[0] << "," << particlesList[1] << ")";
-  TH1D* mpdgapdgb = new TH1D("mpdgapdgb",ss.str().c_str(),1000, 0., sqrts);
+  TH1D* mpdgapdgb = new TH1D("mpdgapdgb", ss.str().c_str(), 1000, 0., sqrts);
 
-  ss.clear(); ss.str("");
+  ss.clear();
+  ss.str("");
   ss << "PT(" << particlesList[0] << "," << particlesList[1] << ")";
-  TH1D* ptpdgapdgb = new TH1D("ptpdgapdgb",ss.str().c_str(),1000, 0., sqrts);
+  TH1D* ptpdgapdgb = new TH1D("ptpdgapdgb", ss.str().c_str(), 1000, 0., sqrts);
 
-  ss.clear(); ss.str("");
+  ss.clear();
+  ss.str("");
   ss << "PZ(" << particlesList[0] << "," << particlesList[1] << ")";
-  TH1D* pzpdgapdgb = new TH1D("pzpdgapdgb",ss.str().c_str(),1000, 0., sqrts);
+  TH1D* pzpdgapdgb = new TH1D("pzpdgapdgb", ss.str().c_str(), 1000, 0., sqrts);
 
   //  loop over the events
   for (size_t i = 0; i < reader->getEntries(podio::Category::Event); ++i) {
@@ -122,43 +128,43 @@ int main(int argc, char** argv)
       event = podio::Frame(reader->readNextEntry(podio::Category::Event));
     auto& mcParticles = event.get<edm4hep::MCParticleCollection>(edm4hep::labels::MCParticles);
     // do more stuff with this event
-    edm4hep::LorentzVectorM *particleA;
-    edm4hep::LorentzVectorM *particleB;
-    for (auto part: mcParticles){
-      if ( part.getPDG() == particlesList[0] && !particleA ){
-	auto momentumA = part.getMomentum();
-	particleA = new edm4hep::LorentzVectorM(momentumA.x, momentumA.y, momentumA.z, part.getMass());
-	double costheta = cos(particleA->Theta());
-	pdgAcostheta->Fill(costheta);
+    edm4hep::LorentzVectorM* particleA;
+    edm4hep::LorentzVectorM* particleB;
+    for (auto part : mcParticles) {
+      if (part.getPDG() == particlesList[0] && !particleA) {
+        auto momentumA = part.getMomentum();
+        particleA = new edm4hep::LorentzVectorM(momentumA.x, momentumA.y, momentumA.z, part.getMass());
+        double costheta = cos(particleA->Theta());
+        pdgAcostheta->Fill(costheta);
       }
-      if ( part.getPDG() == particlesList[1] && !particleB ){
-	auto momentumB = part.getMomentum();
-	particleB = new edm4hep::LorentzVectorM(momentumB.x, momentumB.y, momentumB.z, part.getMass());
-	double costheta = cos(particleB->Theta());
-	pdgBcostheta->Fill(costheta);
+      if (part.getPDG() == particlesList[1] && !particleB) {
+        auto momentumB = part.getMomentum();
+        particleB = new edm4hep::LorentzVectorM(momentumB.x, momentumB.y, momentumB.z, part.getMass());
+        double costheta = cos(particleB->Theta());
+        pdgBcostheta->Fill(costheta);
       }
-      if ( particleA && particleB ){
-	edm4hep::LorentzVectorM part = *particleA + *particleB;
-	mpdgapdgb->Fill(part.mass());
-	ptpdgapdgb->Fill(part.pt());
-	pzpdgapdgb->Fill(part.pz());
+      if (particleA && particleB) {
+        edm4hep::LorentzVectorM part = *particleA + *particleB;
+        mpdgapdgb->Fill(part.mass());
+        ptpdgapdgb->Fill(part.pt());
+        pzpdgapdgb->Fill(part.pz());
       }
     }
     // release memory after an event
-    if ( particleA ) {
+    if (particleA) {
       delete particleA;
-      particleA=0;
+      particleA = 0;
     }
-    if ( particleB ) {
+    if (particleB) {
       delete particleB;
-      particleB=0;
+      particleB = 0;
     }
   }
 
   // now analyze the event
-  
+
   // instantiate the collection as pointer
-  std::unique_ptr<TFile> outputFilePtr(TFile::Open(outFileName.c_str(),"RECREATE"));
+  std::unique_ptr<TFile> outputFilePtr(TFile::Open(outFileName.c_str(), "RECREATE"));
   outputFilePtr->cd();
 
   pdgAcostheta->Write();

--- a/k4GeneratorsConfig/src/pythiaLHERunner.cxx
+++ b/k4GeneratorsConfig/src/pythiaLHERunner.cxx
@@ -5,9 +5,9 @@
 
 // Keywords: two-body decay; astroparticle; python; matplotlib
 
-#include <unistd.h>
 #include "Pythia8/Pythia.h"
 #include "Pythia8Plugins/HepMC3.h"
+#include <unistd.h>
 
 using namespace Pythia8;
 
@@ -15,13 +15,13 @@ using namespace Pythia8;
 
 int main(int argc, char** argv) {
 
-  //read the options
-  std::string filename="Pythia.dat";
-  std::string lhefilename="Pythia.lhe";
-  std::string hepmcFile="Pythia.hepmc";
+  // read the options
+  std::string filename = "Pythia.dat";
+  std::string lhefilename = "Pythia.lhe";
+  std::string hepmcFile = "Pythia.hepmc";
   int c;
-  while ((c = getopt (argc, argv, "f:l:o:")) != -1)
-    switch (c){
+  while ((c = getopt(argc, argv, "f:l:o:")) != -1)
+    switch (c) {
     case 'f':
       filename = optarg;
       break;
@@ -43,21 +43,21 @@ int main(int argc, char** argv) {
     }
   // check existence of the file:
   std::ifstream infile(filename);
-  if ( infile.fail() ) {
+  if (infile.fail()) {
     std::cout << "pythiaLHERunner:: input file with name " << filename << " not found. Exiting" << std::endl;
     exit(0);
   }
 
   // check existence of the file:
   std::ifstream inLHEfile(filename);
-  if ( inLHEfile.fail() ) {
+  if (inLHEfile.fail()) {
     std::cout << "pythiaLHERunner:: input file with name " << lhefilename << " not found. Exiting" << std::endl;
     exit(0);
   }
   // Pythia generator.
   Pythia pythia;
   // add the write hepmc flag to the settings
-  pythia.settings.addFlag("Main:writeHepMC",false);
+  pythia.settings.addFlag("Main:writeHepMC", false);
   // Read in the rest of the settings and data from a separate file.
   pythia.readFile(filename);
 
@@ -80,55 +80,55 @@ int main(int argc, char** argv) {
     exit(0);
   }
 
-  int nEvent  = pythia.mode("Main:numberOfEvents");
-  int nAbort  = pythia.mode("Main:timesAllowErrors");
+  int nEvent = pythia.mode("Main:numberOfEvents");
+  int nAbort = pythia.mode("Main:timesAllowErrors");
 
   // Begin infinite event loop - to be exited at end of file.
   int iAbort = 0;
   for (int iEvent = 0; iEvent < nEvent; ++iEvent) {
     // Generate event.
     if (pythia.next()) {
-      //if (iEvent < 100) pythia.process.list();
-      //if (iEvent < 100) pythia.event.list();
-      // event was ok, write to hepmc file
+      // if (iEvent < 100) pythia.process.list();
+      // if (iEvent < 100) pythia.event.list();
+      //  event was ok, write to hepmc file
       if (hepmc) {
-	// do it in one step:
-	ToHepMC.writeNextEvent(pythia);
-	// temporary correction:
-	//ToHepMC.fillNextEvent(pythia);
-	// now retrieve the cross section
-	//auto xsecptr = ToHepMC.getEventPtr()->cross_section();
-	//if ( !xsecptr ) {
-	//  xsecptr = make_shared<HepMC3::GenCrossSection>();
-	//  ToHepMC.getEventPtr()->set_cross_section(xsecptr);
-	//}
-	// correction the cross section by trial and attempts (temporary fix)
-	//double xsec    = pythia.info.sigmaGen() *pythia.info.nTried()/pythia.info.nAccepted() *1e9;
-	//double xsecerr = 0.;
-	//if ( xsecptr->xsec_errs().size() ){
-	//  xsecerr = xsecptr->xsec_errs()[0];
-	//}
-	//xsecptr->set_cross_section(xsec, xsecerr);
-	//now write the event:
-	//ToHepMC.writeEvent();
+        // do it in one step:
+        ToHepMC.writeNextEvent(pythia);
+        // temporary correction:
+        // ToHepMC.fillNextEvent(pythia);
+        // now retrieve the cross section
+        // auto xsecptr = ToHepMC.getEventPtr()->cross_section();
+        // if ( !xsecptr ) {
+        //  xsecptr = make_shared<HepMC3::GenCrossSection>();
+        //  ToHepMC.getEventPtr()->set_cross_section(xsecptr);
+        //}
+        // correction the cross section by trial and attempts (temporary fix)
+        // double xsec    = pythia.info.sigmaGen() *pythia.info.nTried()/pythia.info.nAccepted() *1e9;
+        // double xsecerr = 0.;
+        // if ( xsecptr->xsec_errs().size() ){
+        //  xsecerr = xsecptr->xsec_errs()[0];
+        //}
+        // xsecptr->set_cross_section(xsec, xsecerr);
+        // now write the event:
+        // ToHepMC.writeEvent();
       }
 
-    }
-    else {
+    } else {
       std::cout << "Event rejected " << std::endl;
       pythia.LHAeventList();
       std::cout << "End of rejected event" << std::endl;
       // Leave event loop if at end of file.
       if (pythia.info.atEndOfFile()) {
-	std::cout << "pythiaLHERunner:: reached EOF at event " << iEvent << " when " << nEvent << " were expected" << std::endl;
-	break;
+        std::cout << "pythiaLHERunner:: reached EOF at event " << iEvent << " when " << nEvent << " were expected"
+                  << std::endl;
+        break;
       }
 
       if (++iAbort >= nAbort) {
-	std::cout << " Event generation aborted prematurely at event " << iEvent << std::endl;
-	std::cout << " LHA input:" << std::endl;
-	pythia.LHAeventList();
-	break;
+        std::cout << " Event generation aborted prematurely at event " << iEvent << std::endl;
+        std::cout << " LHA input:" << std::endl;
+        pythia.LHAeventList();
+        break;
       }
     }
     // End of event loop.

--- a/k4GeneratorsConfig/src/pythiaRunner.cxx
+++ b/k4GeneratorsConfig/src/pythiaRunner.cxx
@@ -16,9 +16,9 @@
 // approach to the same problem.)
 // Also illustrated output to be plotted by Python/Matplotlib/pyplot.
 
-#include <unistd.h>
 #include "Pythia8/Pythia.h"
 #include "Pythia8Plugins/HepMC3.h"
+#include <unistd.h>
 
 #include "pythiaUserHooks.h"
 
@@ -28,11 +28,11 @@ using namespace Pythia8;
 
 int main(int argc, char** argv) {
 
-  //read the options
-  std::string filename="Pythia.dat";
+  // read the options
+  std::string filename = "Pythia.dat";
   int c;
-  while ((c = getopt (argc, argv, "f:")) != -1)
-    switch (c){
+  while ((c = getopt(argc, argv, "f:")) != -1)
+    switch (c) {
     case 'f':
       filename = optarg;
       break;
@@ -46,7 +46,7 @@ int main(int argc, char** argv) {
     }
   // check existence of the file:
   std::ifstream infile(filename);
-  if ( infile.fail() ) {
+  if (infile.fail()) {
     std::cout << "pythiaRunner:: input file with name " << filename << " not found. Exiting" << std::endl;
     exit(0);
   }
@@ -54,17 +54,17 @@ int main(int argc, char** argv) {
   // Pythia generator.
   Pythia pythia;
   // add the write hepmc flag to the settings
-  pythia.settings.addFlag("Main:writeHepMC",false);
-  pythia.settings.addWord("Main:HepMCFile","pythia");
-  pythia.settings.addWord("Main:SelectorsFile","PythiaSelectors");
+  pythia.settings.addFlag("Main:writeHepMC", false);
+  pythia.settings.addWord("Main:HepMCFile", "pythia");
+  pythia.settings.addWord("Main:SelectorsFile", "PythiaSelectors");
   // Read in the rest of the settings and data from a separate file.
   pythia.readFile(filename);
 
   // setup the Userhooks for PYTHIA
   const std::string selectorFile = pythia.word("Main:SelectorsFile");
   auto pythiaUserHooksPtr = make_shared<pythiaUserHooks>(selectorFile);
-  bool success = pythia.setUserHooksPtr( pythiaUserHooksPtr);
-  if ( !success ) 
+  bool success = pythia.setUserHooksPtr(pythiaUserHooksPtr);
+  if (!success)
     std::cout << "WARNING::pythiaRunner::setting of UserHooks was unsuccessful: " << std::endl;
 
   // Initialization.
@@ -77,10 +77,10 @@ int main(int argc, char** argv) {
   Pythia8::Pythia8ToHepMC ToHepMC;
   if (hepmc)
     ToHepMC.setNewFile(hepmcFile);
-  
+
   // Extract settings to be used in the main program.
-  int nEvent  = pythia.mode("Main:numberOfEvents");
-  int nAbort  = pythia.mode("Main:timesAllowErrors");
+  int nEvent = pythia.mode("Main:numberOfEvents");
+  int nAbort = pythia.mode("Main:timesAllowErrors");
 
   // Begin event loop.
   int iAbort = 0;
@@ -89,7 +89,8 @@ int main(int argc, char** argv) {
     // Generate events. Quit if many failures.
     if (!pythia.next()) {
 
-      if (++iAbort < nAbort) continue;
+      if (++iAbort < nAbort)
+        continue;
       cout << " Event generation aborted prematurely, owing to error!\n";
       break;
     }
@@ -97,7 +98,7 @@ int main(int argc, char** argv) {
     if (hepmc) {
       ToHepMC.writeNextEvent(pythia);
     }
-  // End of event loop.
+    // End of event loop.
   }
 
   // Final statistics.

--- a/k4GeneratorsConfig/src/pythiaUserHooks.cxx
+++ b/k4GeneratorsConfig/src/pythiaUserHooks.cxx
@@ -1,293 +1,281 @@
-#include <iostream>
 #include <fstream>
+#include <iostream>
 
 #include "pythiaUserHooks.h"
 
-pythiaUserHooks::pythiaUserHooks(std::string filename) : m_isValid(true){
+pythiaUserHooks::pythiaUserHooks(std::string filename) : m_isValid(true) {
   // add here the reading of the selector cuts
   std::cout << "pythiaUserHooks to restrict phase space instantiated from file " << filename << std::endl;
 
   std::string line;
   std::string delimiter = " ";
   std::ifstream theFile(filename);
-  if ( theFile.is_open() ){
-    while( getline(theFile,line) ){
+  if (theFile.is_open()) {
+    while (getline(theFile, line)) {
       //      std::cout << line << std::endl;
       size_t pos = 0;
       std::string token;
       // first read to decode if it's a 1 or 2 particle selector
       pos = line.find(delimiter);
       unsigned int nPartSelector;
-      if ( pos != std::string::npos ) {
-	token = line.substr(0, pos);
-	nPartSelector = atoi(token.c_str());
-	line.erase(0, pos + delimiter.length());
-      }
-      else {
-	break;
+      if (pos != std::string::npos) {
+        token = line.substr(0, pos);
+        nPartSelector = atoi(token.c_str());
+        line.erase(0, pos + delimiter.length());
+      } else {
+        break;
       }
       m_NbOfParticles.push_back(nPartSelector);
-      if ( nPartSelector == 1 ){
-	for (unsigned int i=0; i<3; i++){
-	  pos = line.find(delimiter);
-	  if ( pos != std::string::npos ){
-	    token = line.substr(0, pos);
-	    switch (i){
-	    case 0:
-	      m_PDGID1.push_back(atoi(token.c_str()));
-	      break;
-	    case 1:
-	      m_Type.push_back(token);
-	      break;
-	    case 2:
-	      m_Comparator.push_back(token);
-	      break;
-	    default:
-	      break;
-	    }
-	    line.erase(0, pos + delimiter.length());
-	  }
-	}
-	// put the rest into the value
-	m_Value.push_back(atof(line.c_str()));
-	// keep the size of all vectors in sync
-	m_PDGID2.push_back(0);
-      }
-      else if ( nPartSelector == 2 ){
-	for (unsigned int i=0; i<4; i++){
-	  pos = line.find(delimiter);
-	  if ( pos != std::string::npos ){
-	    token = line.substr(0, pos);
-	    switch (i){
-	    case 0:
-	      m_PDGID1.push_back(atoi(token.c_str()));
-	      break;
-	    case 1:
-	      m_PDGID2.push_back(atoi(token.c_str()));
-	      break;
-	    case 2:
-	      m_Type.push_back(token);
-	      break;
-	    case 3:
-	      m_Comparator.push_back(token);
-	      break;
-	    default:
-	      break;
-	    }
-	    line.erase(0, pos + delimiter.length());
-	  }
-	}
-	// put the rest into the value
-	m_Value.push_back(atof(line.c_str()));
+      if (nPartSelector == 1) {
+        for (unsigned int i = 0; i < 3; i++) {
+          pos = line.find(delimiter);
+          if (pos != std::string::npos) {
+            token = line.substr(0, pos);
+            switch (i) {
+            case 0:
+              m_PDGID1.push_back(atoi(token.c_str()));
+              break;
+            case 1:
+              m_Type.push_back(token);
+              break;
+            case 2:
+              m_Comparator.push_back(token);
+              break;
+            default:
+              break;
+            }
+            line.erase(0, pos + delimiter.length());
+          }
+        }
+        // put the rest into the value
+        m_Value.push_back(atof(line.c_str()));
+        // keep the size of all vectors in sync
+        m_PDGID2.push_back(0);
+      } else if (nPartSelector == 2) {
+        for (unsigned int i = 0; i < 4; i++) {
+          pos = line.find(delimiter);
+          if (pos != std::string::npos) {
+            token = line.substr(0, pos);
+            switch (i) {
+            case 0:
+              m_PDGID1.push_back(atoi(token.c_str()));
+              break;
+            case 1:
+              m_PDGID2.push_back(atoi(token.c_str()));
+              break;
+            case 2:
+              m_Type.push_back(token);
+              break;
+            case 3:
+              m_Comparator.push_back(token);
+              break;
+            default:
+              break;
+            }
+            line.erase(0, pos + delimiter.length());
+          }
+        }
+        // put the rest into the value
+        m_Value.push_back(atof(line.c_str()));
       }
     }
-  }
-  else {
+  } else {
     std::cout << "pythiaUserHooks::file could not be opened, not applying user cuts" << std::endl;
     m_isValid = false;
   }
 
   // check consistency
-  if ( m_NbOfParticles.size() != m_PDGID1.size() || m_PDGID1.size() != m_PDGID2.size() || m_PDGID1.size() != m_Value.size() || m_Value.size() != m_Type.size() ){
+  if (m_NbOfParticles.size() != m_PDGID1.size() || m_PDGID1.size() != m_PDGID2.size() ||
+      m_PDGID1.size() != m_Value.size() || m_Value.size() != m_Type.size()) {
     m_isValid = false;
     std::cout << "Inconsistent definition of 1 particle selector in pythiaUserHooks" << std::endl;
   }
 
   print();
 }
-pythiaUserHooks::~pythiaUserHooks(){}
+pythiaUserHooks::~pythiaUserHooks() {}
 
-bool pythiaUserHooks::canVetoProcessLevel(){
-  return true;
-}
+bool pythiaUserHooks::canVetoProcessLevel() { return true; }
 
-bool pythiaUserHooks::doVetoProcessLevel(Pythia8::Event& event){
+bool pythiaUserHooks::doVetoProcessLevel(Pythia8::Event& event) {
   // if the selectors are not configured correctly, do not veto...
-  if ( !m_isValid ) return false;
+  if (!m_isValid)
+    return false;
   // ensure that the veto is called
-  for (unsigned int i=0; i< event.size(); i++){
+  for (unsigned int i = 0; i < event.size(); i++) {
     Particle part1 = event[i];
-    if ( part1.status() > 0 ) {
+    if (part1.status() > 0) {
       // if we see a veto reason do not waist time and return a veto, otherwirse continue
-      if ( Veto1ParticleSelector(part1.e(),part1.px(),part1.py(),part1.pz(),part1.id()) ) {
-	return true;
+      if (Veto1ParticleSelector(part1.e(), part1.px(), part1.py(), part1.pz(), part1.id())) {
+        return true;
       }
     }
-    for (unsigned int j=0; j< event.size(); j++){
+    for (unsigned int j = 0; j < event.size(); j++) {
       Particle part2 = event[j];
-      if ( i != j && part1.status() > 0 && part2.status() > 0 ) {
-	if ( Veto2ParticleSelector(part1.e(),part1.px(),part1.py(),part1.pz(),part1.id(),
-				   part2.e(),part2.px(),part2.py(),part2.pz(),part2.id()) ) {
-	  return true;
-	}
+      if (i != j && part1.status() > 0 && part2.status() > 0) {
+        if (Veto2ParticleSelector(part1.e(), part1.px(), part1.py(), part1.pz(), part1.id(), part2.e(), part2.px(),
+                                  part2.py(), part2.pz(), part2.id())) {
+          return true;
+        }
       }
     }
   }
-  
+
   return false;
 }
 
-bool pythiaUserHooks::Veto1ParticleSelector(double energy, double px, double py, double pz, int pdg){
+bool pythiaUserHooks::Veto1ParticleSelector(double energy, double px, double py, double pz, int pdg) {
 
   bool vetoed = false;
-  for (unsigned int i=0; i<m_PDGID1.size(); i++){
-    if (m_NbOfParticles[i] != 1 ) continue;
-    if ( pdg == m_PDGID1[i] ){
+  for (unsigned int i = 0; i < m_PDGID1.size(); i++) {
+    if (m_NbOfParticles[i] != 1)
+      continue;
+    if (pdg == m_PDGID1[i]) {
       double value = 0.;
-      if ( m_Type[i].find("PT") != std::string::npos ){
-	value = PT(px,py);
-      }
-      else if ( m_Type[i].find("ET") != std::string::npos ){
-	value = ET(energy,px,py,pz);
-      }
-      else if ( m_Type[i].find("Rapidity") != std::string::npos ){
-	value = Rapidity(energy,pz);
-      }
-      else if ( m_Type[i].find("Theta") != std::string::npos ){
-	value = Theta(px,py,pz);
-      }
-      else if ( m_Type[i].find("Eta") != std::string::npos ){
-	value = Eta(px,py,pz);
+      if (m_Type[i].find("PT") != std::string::npos) {
+        value = PT(px, py);
+      } else if (m_Type[i].find("ET") != std::string::npos) {
+        value = ET(energy, px, py, pz);
+      } else if (m_Type[i].find("Rapidity") != std::string::npos) {
+        value = Rapidity(energy, pz);
+      } else if (m_Type[i].find("Theta") != std::string::npos) {
+        value = Theta(px, py, pz);
+      } else if (m_Type[i].find("Eta") != std::string::npos) {
+        value = Eta(px, py, pz);
       }
       // now we have the value, we need the comparator
-      if ( m_Comparator[i].find(">") != std::string::npos ){
-	if ( !(value > m_Value[i]) ) vetoed = true;
-      }
-      else if ( m_Comparator[i].find("<") != std::string::npos ){
-	if ( !(value < m_Value[i]) ) vetoed = true;
-      }
-      else {
-	std::cout << "pythiaUserHooks::Vecto1Particle Comparator request unknown " << m_Comparator[i] << std::endl;
+      if (m_Comparator[i].find(">") != std::string::npos) {
+        if (!(value > m_Value[i]))
+          vetoed = true;
+      } else if (m_Comparator[i].find("<") != std::string::npos) {
+        if (!(value < m_Value[i]))
+          vetoed = true;
+      } else {
+        std::cout << "pythiaUserHooks::Vecto1Particle Comparator request unknown " << m_Comparator[i] << std::endl;
       }
     }
   }
   return vetoed;
 }
 bool pythiaUserHooks::Veto2ParticleSelector(double energy1, double px1, double py1, double pz1, int pdg1,
-					    double energy2, double px2, double py2, double pz2, int pdg2){
+                                            double energy2, double px2, double py2, double pz2, int pdg2) {
 
   bool vetoed = false;
-  for (unsigned int i=0; i<m_PDGID1.size(); i++){
-    if (m_NbOfParticles[i] != 2 ) continue;
-    if ( pdg1 == m_PDGID1[i] && pdg2 == m_PDGID2[i] ){
+  for (unsigned int i = 0; i < m_PDGID1.size(); i++) {
+    if (m_NbOfParticles[i] != 2)
+      continue;
+    if (pdg1 == m_PDGID1[i] && pdg2 == m_PDGID2[i]) {
       double value = 0.;
-      if ( m_Type[i].find("Mass") != std::string::npos ){
-	value = Mass(energy1,px1,py1,pz1,
-		     energy2,px2,py2,pz2);
-      }
-      else if ( m_Type[i].find("Angle") != std::string::npos ){
-	value = Angle(px1,py1,pz1,px2,py2,pz2);
-      }
-      else if ( m_Type[i].find("DeltaEta") != std::string::npos ){
-	value = abs(Eta(px1,py1,pz1)-Eta(px2,py2,pz2));
-      }
-      else if ( m_Type[i].find("DeltaY") != std::string::npos ){
-	value = abs(Rapidity(energy1,pz1)-Rapidity(energy2,pz2));
-      }
-      else if ( m_Type[i].find("DeltaPhi") != std::string::npos ){
-	value = Angle(px1,py1,0.,px2,py2,0.);
-      }
-      else if ( m_Type[i].find("DeltaR") != std::string::npos ){
-	double deltaPhi = Angle(px1,py1,0.,px2,py2,0.);
-	double deltaEta = abs(Eta(px1,py1,pz1)-Eta(px2,py2,pz2));
-	value = sqrt(deltaPhi*deltaPhi+deltaEta*deltaEta);
+      if (m_Type[i].find("Mass") != std::string::npos) {
+        value = Mass(energy1, px1, py1, pz1, energy2, px2, py2, pz2);
+      } else if (m_Type[i].find("Angle") != std::string::npos) {
+        value = Angle(px1, py1, pz1, px2, py2, pz2);
+      } else if (m_Type[i].find("DeltaEta") != std::string::npos) {
+        value = abs(Eta(px1, py1, pz1) - Eta(px2, py2, pz2));
+      } else if (m_Type[i].find("DeltaY") != std::string::npos) {
+        value = abs(Rapidity(energy1, pz1) - Rapidity(energy2, pz2));
+      } else if (m_Type[i].find("DeltaPhi") != std::string::npos) {
+        value = Angle(px1, py1, 0., px2, py2, 0.);
+      } else if (m_Type[i].find("DeltaR") != std::string::npos) {
+        double deltaPhi = Angle(px1, py1, 0., px2, py2, 0.);
+        double deltaEta = abs(Eta(px1, py1, pz1) - Eta(px2, py2, pz2));
+        value = sqrt(deltaPhi * deltaPhi + deltaEta * deltaEta);
       }
       // now we have the value, we need the comparator
-      if ( m_Comparator[i].find(">") != std::string::npos ){
-	if ( !(value > m_Value[i]) ) vetoed = true;
-      }
-      else if ( m_Comparator[i].find("<") != std::string::npos ){
-	if ( !(value < m_Value[i]) ) vetoed = true;
-      }
-      else {
-	std::cout << "pythiaUserHooks::Veto2Particles Comparator request unknown " << m_Comparator[i] << std::endl;
+      if (m_Comparator[i].find(">") != std::string::npos) {
+        if (!(value > m_Value[i]))
+          vetoed = true;
+      } else if (m_Comparator[i].find("<") != std::string::npos) {
+        if (!(value < m_Value[i]))
+          vetoed = true;
+      } else {
+        std::cout << "pythiaUserHooks::Veto2Particles Comparator request unknown " << m_Comparator[i] << std::endl;
       }
     }
   }
   return vetoed;
 }
 
-double pythiaUserHooks::PT(double px, double py){
-  
-  double pt = px*px+py*py;
-  if (pt >= 0 ){
+double pythiaUserHooks::PT(double px, double py) {
+
+  double pt = px * px + py * py;
+  if (pt >= 0) {
     pt = sqrt(pt);
-  }
-  else {
+  } else {
     pt = 0;
   }
   return pt;
 }
-double pythiaUserHooks::ET(double energy, double px, double py, double pz){
+double pythiaUserHooks::ET(double energy, double px, double py, double pz) {
 
-  double et = energy * sin(Theta(px,py,pz));
-  
+  double et = energy * sin(Theta(px, py, pz));
+
   return et;
 }
-double pythiaUserHooks::Rapidity(double energy, double pz){
+double pythiaUserHooks::Rapidity(double energy, double pz) {
 
-  double rap = 0.5*log((energy+pz)/(energy-pz));
+  double rap = 0.5 * log((energy + pz) / (energy - pz));
 
   return rap;
 }
-double pythiaUserHooks::Theta(double px, double py, double pz){
+double pythiaUserHooks::Theta(double px, double py, double pz) {
 
   double costheta = 0.;
-  double pt = PT(px,py);
-  double p = pt*pt+pz*pz;
-  if ( p >= 0.){
+  double pt = PT(px, py);
+  double p = pt * pt + pz * pz;
+  if (p >= 0.) {
     p = sqrt(p);
   }
-  if ( p != 0. ){
-    costheta = pz/p;
+  if (p != 0.) {
+    costheta = pz / p;
   }
   double theta = acos(costheta);
 
   return theta;
 }
-double pythiaUserHooks::Eta(double px, double py, double pz){
+double pythiaUserHooks::Eta(double px, double py, double pz) {
 
-  double theta = Theta(px,py,pz);
-  double eta = -log(tan(theta/2.));
+  double theta = Theta(px, py, pz);
+  double eta = -log(tan(theta / 2.));
 
   return eta;
 }
-double pythiaUserHooks::Mass(double energy1, double px1, double py1, double pz1, double energy2, double px2, double py2, double pz2){
+double pythiaUserHooks::Mass(double energy1, double px1, double py1, double pz1, double energy2, double px2, double py2,
+                             double pz2) {
 
-  double mass = (energy1+energy2)*(energy1+energy2)
-    -(px1+px2)*(px1+px2)-(py1+py2)*(py1+py2)-(pz1+pz2)*(pz1+pz2);
-  if (mass > 0.){
+  double mass = (energy1 + energy2) * (energy1 + energy2) - (px1 + px2) * (px1 + px2) - (py1 + py2) * (py1 + py2) -
+                (pz1 + pz2) * (pz1 + pz2);
+  if (mass > 0.) {
     mass = sqrt(mass);
   }
   return mass;
 }
 
-double pythiaUserHooks::Angle(double px1, double py1, double pz1, double px2, double py2, double pz2){
-  double top = px1*px2+py1*py2+pz1*pz2;
-  double bottom = (px1*px1+py1*py1+pz1*pz1)*
-    (px2*px2+py2*py2+pz2*pz2);
+double pythiaUserHooks::Angle(double px1, double py1, double pz1, double px2, double py2, double pz2) {
+  double top = px1 * px2 + py1 * py2 + pz1 * pz2;
+  double bottom = (px1 * px1 + py1 * py1 + pz1 * pz1) * (px2 * px2 + py2 * py2 + pz2 * pz2);
   bottom = sqrt(bottom);
-  
+
   double angle = 0.;
-  if (bottom != 0.){
-    angle = acos(top/bottom);
-  } 
+  if (bottom != 0.) {
+    angle = acos(top / bottom);
+  }
 
   return angle;
 }
 
- void pythiaUserHooks::print(){
-    
+void pythiaUserHooks::print() {
+
   std::cout << "pythiaUserHooks::Single Particle Selectors" << std::endl;
-  for (unsigned int i=0; i<m_PDGID1.size(); i++){
+  for (unsigned int i = 0; i < m_PDGID1.size(); i++) {
     std::cout << "PDGID: " << m_PDGID1[i] << " ";
-    if ( i < m_PDGID2.size() && m_NbOfParticles[i] == 2)
+    if (i < m_PDGID2.size() && m_NbOfParticles[i] == 2)
       std::cout << "PDGID: " << m_PDGID2[i] << " ";
-    if ( i < m_Type.size() )
+    if (i < m_Type.size())
       std::cout << "Type: " << m_Type[i] << " ";
-    if ( i < m_Comparator.size() )
+    if (i < m_Comparator.size())
       std::cout << "Type: " << m_Comparator[i] << " ";
-    if ( i < m_Value.size() )
+    if (i < m_Value.size())
       std::cout << "Value: " << m_Value[i] << " ";
     std::cout << std::endl;
   }

--- a/k4GeneratorsConfig/src/pythiaUserHooks.h
+++ b/k4GeneratorsConfig/src/pythiaUserHooks.h
@@ -9,34 +9,32 @@ using namespace Pythia8;
 
 class pythiaUserHooks : public UserHooks {
 
- public:
-  //Constructor creates anti-kT jet finder with (-1, R, pTmin, etaMax).
+public:
+  // Constructor creates anti-kT jet finder with (-1, R, pTmin, etaMax).
   pythiaUserHooks(std::string);
-  
+
   // Destructor deletes anti-kT jet finder and prints histograms.
   ~pythiaUserHooks();
 
   // we work at the parton level
   bool canVetoProcessLevel();
-  bool doVetoProcessLevel(Event& );
-  
+  bool doVetoProcessLevel(Event&);
+
   bool Veto1ParticleSelector(double, double, double, double, int);
-  bool Veto2ParticleSelector(double, double, double, double, int,
-			     double, double, double, double, int );
+  bool Veto2ParticleSelector(double, double, double, double, int, double, double, double, double, int);
 
   double PT(double, double);
   double ET(double, double, double, double);
-  double Rapidity(double,double);
+  double Rapidity(double, double);
   double Theta(double, double, double);
   double Eta(double, double, double);
-  
+
   double Mass(double, double, double, double, double, double, double, double);
   double Angle(double, double, double, double, double, double);
 
   void print();
 
 private:
-
   bool m_isValid;
 
   std::vector<unsigned int> m_NbOfParticles;
@@ -45,7 +43,6 @@ private:
   std::vector<string> m_Type;
   std::vector<string> m_Comparator;
   std::vector<double> m_Value;
-
 };
 
 #endif

--- a/k4GeneratorsConfig/src/xsection.cxx
+++ b/k4GeneratorsConfig/src/xsection.cxx
@@ -1,174 +1,144 @@
 #include "xsection.h"
 #include <iostream>
 
-#include "podio/Frame.h"
 #include "edm4hep/Constants.h"
 #include "edm4hep/GeneratorEventParametersCollection.h"
 #include "edm4hep/GeneratorToolInfo.h"
+#include "podio/Frame.h"
 
-k4GeneratorsConfig::xsection::xsection():
-  m_xsection(0.),
-  m_xsectionError(0.),
-  m_sqrts(0.),
-  m_generator(""),
-  m_process(""),
-  m_file(""),
-  m_isValid(false)
-{
+k4GeneratorsConfig::xsection::xsection()
+    : m_xsection(0.), m_xsectionError(0.), m_sqrts(0.), m_generator(""), m_process(""), m_file(""), m_isValid(false) {
   m_reader = new podio::ROOTReader();
 }
-k4GeneratorsConfig::xsection::xsection(double xsec, double xsecError, double sqrts, std::string generator, std::string process, std::string file)
-{
-  m_xsection      = xsec;
+k4GeneratorsConfig::xsection::xsection(double xsec, double xsecError, double sqrts, std::string generator,
+                                       std::string process, std::string file) {
+  m_xsection = xsec;
   m_xsectionError = xsecError;
-  m_sqrts         = sqrts;
-  m_generator     = generator;
-  m_process       = process;
-  m_file          = file;
+  m_sqrts = sqrts;
+  m_generator = generator;
+  m_process = process;
+  m_file = file;
 
-  m_reader  = new podio::ROOTReader();
+  m_reader = new podio::ROOTReader();
   m_isValid = processFile();
 }
-k4GeneratorsConfig::xsection::xsection(const xsection& theOriginal)
-{
-  if ( this != &theOriginal ){
-    m_xsection      = theOriginal.m_xsection;
+k4GeneratorsConfig::xsection::xsection(const xsection& theOriginal) {
+  if (this != &theOriginal) {
+    m_xsection = theOriginal.m_xsection;
     m_xsectionError = theOriginal.m_xsectionError;
-    m_sqrts         = theOriginal.m_sqrts;
-    m_generator     = theOriginal.m_generator;
-    m_process       = theOriginal.m_process;
-    m_file          = theOriginal.m_file;
-    m_isValid       = theOriginal.m_isValid;
+    m_sqrts = theOriginal.m_sqrts;
+    m_generator = theOriginal.m_generator;
+    m_process = theOriginal.m_process;
+    m_file = theOriginal.m_file;
+    m_isValid = theOriginal.m_isValid;
     m_reader = new podio::ROOTReader();
   }
 }
-k4GeneratorsConfig::xsection& k4GeneratorsConfig::xsection::operator=(const xsection& theOriginal)
-{
-  if ( this != &theOriginal ){
-    m_xsection      = theOriginal.m_xsection;
+k4GeneratorsConfig::xsection& k4GeneratorsConfig::xsection::operator=(const xsection& theOriginal) {
+  if (this != &theOriginal) {
+    m_xsection = theOriginal.m_xsection;
     m_xsectionError = theOriginal.m_xsectionError;
-    m_sqrts         = theOriginal.m_sqrts;
-    m_generator     = theOriginal.m_generator;
-    m_process       = theOriginal.m_process;
-    m_file          = theOriginal.m_file;
-    m_isValid       = theOriginal.m_isValid;
-    if (m_reader != 0 ) delete m_reader;
+    m_sqrts = theOriginal.m_sqrts;
+    m_generator = theOriginal.m_generator;
+    m_process = theOriginal.m_process;
+    m_file = theOriginal.m_file;
+    m_isValid = theOriginal.m_isValid;
+    if (m_reader != 0)
+      delete m_reader;
     m_reader = new podio::ROOTReader();
   }
 
   return *this;
 }
-k4GeneratorsConfig::xsection::~xsection(){
-  delete m_reader;m_reader=0;
+k4GeneratorsConfig::xsection::~xsection() {
+  delete m_reader;
+  m_reader = 0;
 }
-bool k4GeneratorsConfig::xsection::processFile(){
+bool k4GeneratorsConfig::xsection::processFile() {
 
   // open the edm4hep file
   m_reader->openFile(m_file);
 
   // retrieve the RunInfo for the weight names, there should only be 1 entry per Run
-  if ( m_reader->getEntries(podio::Category::Run) == 0 ){
+  if (m_reader->getEntries(podio::Category::Run) == 0) {
     return false;
   }
   auto runinfo = podio::Frame(m_reader->readNextEntry(podio::Category::Run));
-  const auto possibleWeightNames = runinfo.getParameter<std::vector<std::string>>(edm4hep::labels::GeneratorWeightNames);
+  const auto possibleWeightNames =
+      runinfo.getParameter<std::vector<std::string>>(edm4hep::labels::GeneratorWeightNames);
   const auto weightNames = possibleWeightNames.value();
-  if ( weightNames.size() == 0 ){
+  if (weightNames.size() == 0) {
     std::cout << "k4GeneratorsConfig::Warning: no weight names were found" << std::endl;
   }
 
   auto toolInfos = edm4hep::utils::getGenToolInfos(runinfo);
-  if ( toolInfos.size() > 0 ){
+  if (toolInfos.size() > 0) {
     m_generator = toolInfos[0].name;
-  }
-  else {
+  } else {
     std::cout << "k4GeneratorsConfig::Warning ToolInfos not available" << std::endl;
   }
 
   // retrieve the cross section for the last event if not possible it's not valid
-  if ( m_reader->getEntries(podio::Category::Event) == 0 ){
-    m_xsection      = 0.;
+  if (m_reader->getEntries(podio::Category::Event) == 0) {
+    m_xsection = 0.;
     m_xsectionError = 0.;
     return false;
   }
   unsigned int lastEvent = m_reader->getEntries(podio::Category::Event) - 1;
-  auto event = podio::Frame(m_reader->readEntry(podio::Category::Event,lastEvent));
+  auto event = podio::Frame(m_reader->readEntry(podio::Category::Event, lastEvent));
 
   // now get the event parameters there must be at least one entry!
-  const edm4hep::GeneratorEventParametersCollection &genParametersCollection = event.get<edm4hep::GeneratorEventParametersCollection>(edm4hep::labels::GeneratorEventParameters);
-  if ( genParametersCollection.size() == 0 ) return false;
+  const edm4hep::GeneratorEventParametersCollection& genParametersCollection =
+      event.get<edm4hep::GeneratorEventParametersCollection>(edm4hep::labels::GeneratorEventParameters);
+  if (genParametersCollection.size() == 0)
+    return false;
   edm4hep::GeneratorEventParameters genParameters = genParametersCollection[0];
-  
+
   // decode sqrts
   m_sqrts = genParameters.getSqrts();
 
   // decode the cross sections
   m_xsection = 0.;
-  if ( genParameters.crossSections_size() > 0 ){
-    m_xsection =  genParameters.getCrossSections()[0];
+  if (genParameters.crossSections_size() > 0) {
+    m_xsection = genParameters.getCrossSections()[0];
   }
-  
+
   // decode the cross section errors
   m_xsectionError = 0.;
-  if ( genParameters.crossSectionErrors_size() > 0 ){
-    m_xsectionError =  genParameters.getCrossSectionErrors()[0];
+  if (genParameters.crossSectionErrors_size() > 0) {
+    m_xsectionError = genParameters.getCrossSectionErrors()[0];
   }
 
   return true;
 }
-void k4GeneratorsConfig::xsection::setXsection(double xsec){
-  m_xsection = xsec;
-}
-void k4GeneratorsConfig::xsection::setXsection(double xsec, double err){
+void k4GeneratorsConfig::xsection::setXsection(double xsec) { m_xsection = xsec; }
+void k4GeneratorsConfig::xsection::setXsection(double xsec, double err) {
   setXsection(xsec);
   setXsectionError(err);
 }
-void k4GeneratorsConfig::xsection::setXsectionError(double error){
-  m_xsectionError = error;
-}
-void k4GeneratorsConfig::xsection::setSQRTS(double sqrts){
-  m_sqrts = sqrts;
-}
-void k4GeneratorsConfig::xsection::setGenerator(std::string gen){
-  m_generator = gen;
-}
-void k4GeneratorsConfig::xsection::setProcess(std::string proc){
-  m_process = proc;
-}
-void k4GeneratorsConfig::xsection::setFile(std::string file){
+void k4GeneratorsConfig::xsection::setXsectionError(double error) { m_xsectionError = error; }
+void k4GeneratorsConfig::xsection::setSQRTS(double sqrts) { m_sqrts = sqrts; }
+void k4GeneratorsConfig::xsection::setGenerator(std::string gen) { m_generator = gen; }
+void k4GeneratorsConfig::xsection::setProcess(std::string proc) { m_process = proc; }
+void k4GeneratorsConfig::xsection::setFile(std::string file) {
   m_file = file;
   m_isValid = processFile();
 }
-double k4GeneratorsConfig::xsection::Xsection(){
-  return m_xsection;
-}
-double k4GeneratorsConfig::xsection::XsectionError(){
-  return m_xsectionError;
-}
-double k4GeneratorsConfig::xsection::SQRTS(){
-  return m_sqrts;
-}
-std::string k4GeneratorsConfig::xsection::Generator(){
-  return m_generator;
-}
-std::string k4GeneratorsConfig::xsection::Process(){
-  return m_process;
-}
-std::string k4GeneratorsConfig::xsection::File(){
-  return m_file;
-}
-bool k4GeneratorsConfig::xsection::isValid(){
-  return m_isValid;
-}
-void k4GeneratorsConfig::xsection::Print(){
+double k4GeneratorsConfig::xsection::Xsection() { return m_xsection; }
+double k4GeneratorsConfig::xsection::XsectionError() { return m_xsectionError; }
+double k4GeneratorsConfig::xsection::SQRTS() { return m_sqrts; }
+std::string k4GeneratorsConfig::xsection::Generator() { return m_generator; }
+std::string k4GeneratorsConfig::xsection::Process() { return m_process; }
+std::string k4GeneratorsConfig::xsection::File() { return m_file; }
+bool k4GeneratorsConfig::xsection::isValid() { return m_isValid; }
+void k4GeneratorsConfig::xsection::Print() {
   std::cout << std::endl;
   std::cout << "xsection object summary:" << std::endl;
-  std::cout << "File          : " << m_file          << std::endl;
-  std::cout << "Process       : " << m_process       << std::endl;
-  std::cout << "SQRTS         : " << m_sqrts         << std::endl;
-  std::cout << "Generator     : " << m_generator     << std::endl;
-  std::cout << "xsection valid: " << m_isValid       << std::endl;
-  std::cout << "xsection      : " << m_xsection
-	    << " +- "             << m_xsectionError << " pb"<< std::endl;
+  std::cout << "File          : " << m_file << std::endl;
+  std::cout << "Process       : " << m_process << std::endl;
+  std::cout << "SQRTS         : " << m_sqrts << std::endl;
+  std::cout << "Generator     : " << m_generator << std::endl;
+  std::cout << "xsection valid: " << m_isValid << std::endl;
+  std::cout << "xsection      : " << m_xsection << " +- " << m_xsectionError << " pb" << std::endl;
   std::cout << std::endl;
 }

--- a/k4GeneratorsConfig/src/xsection.h
+++ b/k4GeneratorsConfig/src/xsection.h
@@ -7,17 +7,17 @@
 
 namespace k4GeneratorsConfig {
 class xsection {
- public:
+public:
   xsection();
-  xsection(double,double,double,std::string,std::string,std::string);
-  xsection(const xsection &);
-  xsection& operator=(const xsection &);
+  xsection(double, double, double, std::string, std::string, std::string);
+  xsection(const xsection&);
+  xsection& operator=(const xsection&);
   ~xsection();
 
   bool processFile();
 
   void setXsection(double);
-  void setXsection(double,double);
+  void setXsection(double, double);
   void setXsectionError(double);
   void setSQRTS(double);
   void setGenerator(std::string);
@@ -34,17 +34,16 @@ class xsection {
 
   void Print();
 
- private:
-  double      m_xsection;
-  double      m_xsectionError;
-  double      m_sqrts;
+private:
+  double m_xsection;
+  double m_xsectionError;
+  double m_sqrts;
   std::string m_generator;
   std::string m_process;
   std::string m_file;
-  bool        m_isValid;
-  podio::ROOTReader *m_reader;
-
+  bool m_isValid;
+  podio::ROOTReader* m_reader;
 };
-}
+} // namespace k4GeneratorsConfig
 
 #endif

--- a/k4GeneratorsConfig/src/xsection2Root.cxx
+++ b/k4GeneratorsConfig/src/xsection2Root.cxx
@@ -1,171 +1,171 @@
-#include <sstream>
 #include "xsection2Root.h"
+#include <sstream>
 
 #include "TCanvas.h"
 #include "TMultiGraph.h"
 
-k4GeneratorsConfig::xsection2Root::xsection2Root()
-{
-  m_file = new TFile("xsection2RootSummary.root","RECREATE");
+k4GeneratorsConfig::xsection2Root::xsection2Root() {
+  m_file = new TFile("xsection2RootSummary.root", "RECREATE");
   Init();
 }
-k4GeneratorsConfig::xsection2Root::xsection2Root(std::string file)
-{
-  m_file = new TFile(file.c_str(),"RECREATE");
+k4GeneratorsConfig::xsection2Root::xsection2Root(std::string file) {
+  m_file = new TFile(file.c_str(), "RECREATE");
   Init();
 }
-void k4GeneratorsConfig::xsection2Root::Init(){
-  m_tree = new TTree("CrossSections","cross sections");
-  m_tree->Branch("process",&m_process);
-  m_tree->Branch("iprocess",&m_processCode,"iprocess/I");
-  m_tree->Branch("xsec",&m_crossSection,"xsec/D");
-  m_tree->Branch("dxsec",&m_crossSectionError,"dxsec/D");
-  m_tree->Branch("sqrts",&m_sqrts,"sqrts/D");
-  m_tree->Branch("generator",&m_generator);
-  m_tree->Branch("igenerator",&m_generatorCode,"igenerator/I");
+void k4GeneratorsConfig::xsection2Root::Init() {
+  m_tree = new TTree("CrossSections", "cross sections");
+  m_tree->Branch("process", &m_process);
+  m_tree->Branch("iprocess", &m_processCode, "iprocess/I");
+  m_tree->Branch("xsec", &m_crossSection, "xsec/D");
+  m_tree->Branch("dxsec", &m_crossSectionError, "dxsec/D");
+  m_tree->Branch("sqrts", &m_sqrts, "sqrts/D");
+  m_tree->Branch("generator", &m_generator);
+  m_tree->Branch("igenerator", &m_generatorCode, "igenerator/I");
 }
-k4GeneratorsConfig::xsection2Root::~xsection2Root(){
-}
-void k4GeneratorsConfig::xsection2Root::Execute(xsection &xsec){
-  add2Tree(xsec);
-}
-void k4GeneratorsConfig::xsection2Root::add2Tree(xsection &xsec){
+k4GeneratorsConfig::xsection2Root::~xsection2Root() {}
+void k4GeneratorsConfig::xsection2Root::Execute(xsection& xsec) { add2Tree(xsec); }
+void k4GeneratorsConfig::xsection2Root::add2Tree(xsection& xsec) {
 
   // do things
-  m_crossSection      = xsec.Xsection();
+  m_crossSection = xsec.Xsection();
   m_crossSectionError = xsec.XsectionError();
-  m_sqrts             = xsec.SQRTS();
-  m_generator         = xsec.Generator();
+  m_sqrts = xsec.SQRTS();
+  m_generator = xsec.Generator();
 
-  //need to remove - from the names
-  if ( m_generator.find("-") != std::string::npos ){
-    m_generator.erase(m_generator.find("-"),1);
+  // need to remove - from the names
+  if (m_generator.find("-") != std::string::npos) {
+    m_generator.erase(m_generator.find("-"), 1);
   }
-  if ( m_generator.find("@") != std::string::npos ){
-    m_generator.erase(m_generator.find("@"),1);
+  if (m_generator.find("@") != std::string::npos) {
+    m_generator.erase(m_generator.find("@"), 1);
   }
-  if ( m_generator.find("_") != std::string::npos ){
-    m_generator.erase(m_generator.find("_"),1);
+  if (m_generator.find("_") != std::string::npos) {
+    m_generator.erase(m_generator.find("_"), 1);
   }
-  
+
   // assign a code for each generator
-  if ( std::find(m_generatorsList.begin(),m_generatorsList.end(),m_generator)== m_generatorsList.end() ) {
+  if (std::find(m_generatorsList.begin(), m_generatorsList.end(), m_generator) == m_generatorsList.end()) {
     m_generatorsList.push_back(m_generator);
   }
-  
-  m_generatorCode     = std::find(m_generatorsList.begin(),m_generatorsList.end(),m_generator) - m_generatorsList.begin();
+
+  m_generatorCode = std::find(m_generatorsList.begin(), m_generatorsList.end(), m_generator) - m_generatorsList.begin();
 
   // process needs to be processed to remove eveything from the subscript on:
-  m_process           = xsec.Process();
-  if ( m_process.find_last_of("_") != std::string::npos ){
+  m_process = xsec.Process();
+  if (m_process.find_last_of("_") != std::string::npos) {
     m_process.erase(m_process.find_last_of("_"));
   }
   // assign a code for each process
-  if ( std::find(m_processesList.begin(),m_processesList.end(),m_process)== m_processesList.end() ) {
+  if (std::find(m_processesList.begin(), m_processesList.end(), m_process) == m_processesList.end()) {
     m_processesList.push_back(m_process);
   }
-  
-  m_processCode     = std::find(m_processesList.begin(),m_processesList.end(),m_process) - m_processesList.begin();
+
+  m_processCode = std::find(m_processesList.begin(), m_processesList.end(), m_process) - m_processesList.begin();
 
   // write to the tree
   m_tree->Fill();
-  
 }
-void k4GeneratorsConfig::xsection2Root::Finalize(){
+void k4GeneratorsConfig::xsection2Root::Finalize() {
   m_file->cd();
   writeHistos();
   writeTree();
   m_file->Close();
-  
 }
-void k4GeneratorsConfig::xsection2Root::writeHistos(){
-  
+void k4GeneratorsConfig::xsection2Root::writeHistos() {
+
   std::stringstream name, desc;
-  for (auto proc: m_processesList){
-    for (auto gen: m_generatorsList){
+  for (auto proc : m_processesList) {
+    for (auto gen : m_generatorsList) {
       name << gen << proc;
       desc << gen << "::Process: " << proc << ": CrossSection vs Sqrts";
-      m_histos.push_back(new TH2D(name.str().c_str(),desc.str().c_str(),600,0.,600.,1000,0.,10000.));
+      m_histos.push_back(new TH2D(name.str().c_str(), desc.str().c_str(), 600, 0., 600., 1000, 0., 10000.));
       name << "Graph";
       m_graphs.push_back(new TGraphErrors());
-      m_graphs[m_graphs.size()-1]->SetName(name.str().c_str());
-      name.clear(); name.str(""); desc.clear(); desc.str("");
+      m_graphs[m_graphs.size() - 1]->SetName(name.str().c_str());
+      name.clear();
+      name.str("");
+      desc.clear();
+      desc.str("");
     }
     // the profile histograms are per process only: "s" for RMS
     name << proc << "Prof";
     desc << "Process: " << proc << ": CrossSection vs Sqrts";
-    m_profiles.push_back(new TProfile(name.str().c_str(),desc.str().c_str(),6000,0.001,600.001,0.,0.,"s"));
-    name.clear(); name.str("");
+    m_profiles.push_back(new TProfile(name.str().c_str(), desc.str().c_str(), 6000, 0.001, 600.001, 0., 0., "s"));
+    name.clear();
+    name.str("");
     name << proc << "RMS";
-    m_rms.push_back(new TH1D(name.str().c_str(),desc.str().c_str(),6000,0.001,600.001));
-    name.clear(); name.str(""); desc.clear(); desc.str("");
+    m_rms.push_back(new TH1D(name.str().c_str(), desc.str().c_str(), 6000, 0.001, 600.001));
+    name.clear();
+    name.str("");
+    desc.clear();
+    desc.str("");
   }
 
-  //access the data and write to the histo via the index of the generatorList
-  for (unsigned int entry=0; entry < m_tree->GetEntries(); entry++){
+  // access the data and write to the histo via the index of the generatorList
+  for (unsigned int entry = 0; entry < m_tree->GetEntries(); entry++) {
     // a tree for root analysis
     m_tree->GetEntry(entry);
     // calculate the index of histos and graphs
-    unsigned int index = m_generatorCode+m_processCode*m_generatorsList.size();
+    unsigned int index = m_generatorCode + m_processCode * m_generatorsList.size();
     // histos as benchmark
-    m_histos[index]->Fill(m_sqrts,m_crossSection,1.);
+    m_histos[index]->Fill(m_sqrts, m_crossSection, 1.);
     // graphs for pecise drawing
-    m_graphs[index]->AddPoint(m_sqrts,m_crossSection);
-    unsigned int lastPoint = m_graphs[m_generatorCode+m_processCode*m_generatorsList.size()]->GetN()-1;
-    m_graphs[index]->SetPointError(lastPoint,m_sqrts*1e-4,m_crossSectionError);
+    m_graphs[index]->AddPoint(m_sqrts, m_crossSection);
+    unsigned int lastPoint = m_graphs[m_generatorCode + m_processCode * m_generatorsList.size()]->GetN() - 1;
+    m_graphs[index]->SetPointError(lastPoint, m_sqrts * 1e-4, m_crossSectionError);
     // process profile, but make sure it's positive and > 1ab
-    if ( m_crossSection > 1.e-6 ){
-      m_profiles[m_processCode]->Fill(m_sqrts,m_crossSection);
+    if (m_crossSection > 1.e-6) {
+      m_profiles[m_processCode]->Fill(m_sqrts, m_crossSection);
     }
   }
 
   // for the profileRms divide by the Central value if 1+0
-  for (unsigned int i=0; i<m_rms.size(); i++){
+  for (unsigned int i = 0; i < m_rms.size(); i++) {
     // the number of bins is higher by 2 for the vecto overflow and underflow
-    unsigned int nbins = m_profiles[i]->GetNbinsX()+2;
+    unsigned int nbins = m_profiles[i]->GetNbinsX() + 2;
     std::vector<Double_t> content;
-    content.resize(nbins,0.);
+    content.resize(nbins, 0.);
     std::vector<Double_t> error;
-    error.resize(nbins,0.);
+    error.resize(nbins, 0.);
     std::vector<Double_t> almostzero;
-    almostzero.resize(nbins,0.);
-    for (unsigned int k=0; k<nbins ; k++){
+    almostzero.resize(nbins, 0.);
+    for (unsigned int k = 0; k < nbins; k++) {
       content[k] = m_profiles[i]->GetBinContent(k);
-      error[k]   = m_profiles[i]->GetBinError(k);
-      if ( content[k] > 0. ) {
-	error[k]      = error[k]/content[k];
-	almostzero[k] = 1.e-6;
+      error[k] = m_profiles[i]->GetBinError(k);
+      if (content[k] > 0.) {
+        error[k] = error[k] / content[k];
+        almostzero[k] = 1.e-6;
       }
     }
     m_rms[i]->SetContent(&error[0]);
     m_rms[i]->SetError(&almostzero[0]);
   }
-  
+
   // write the histos out
-  for (auto histo: m_histos){
+  for (auto histo : m_histos) {
     histo->Write();
   }
-  for (auto graph: m_graphs){
+  for (auto graph : m_graphs) {
     graph->Write();
   }
-  for (auto prof: m_profiles){
+  for (auto prof : m_profiles) {
     prof->Write();
   }
-  for (auto prof: m_rms){
+  for (auto prof : m_rms) {
     prof->Write();
   }
-  
+
   // produce a png
-  TCanvas *c1 = new TCanvas("c1","CrossSectionsCanvas");
-  for (unsigned int proc=0; proc<m_processesList.size(); proc++){
-    TMultiGraph *mg = new TMultiGraph();
-    for (unsigned int gen=0; gen<m_generatorsList.size(); gen++){
-      unsigned int index = gen+proc*m_generatorsList.size();
+  TCanvas* c1 = new TCanvas("c1", "CrossSectionsCanvas");
+  for (unsigned int proc = 0; proc < m_processesList.size(); proc++) {
+    TMultiGraph* mg = new TMultiGraph();
+    for (unsigned int gen = 0; gen < m_generatorsList.size(); gen++) {
+      unsigned int index = gen + proc * m_generatorsList.size();
       m_graphs[index]->SetStats(kFALSE);
-      m_graphs[index]->SetMarkerStyle(20+gen);
+      m_graphs[index]->SetMarkerStyle(20 + gen);
       m_graphs[index]->SetMarkerColor(gen);
       m_graphs[index]->SetMarkerSize(1.25);
-      mg->Add(m_graphs[index],"AP");
+      mg->Add(m_graphs[index], "AP");
     }
     // draw and set the stuff for the multigraphs
     mg->Draw("AP");
@@ -173,12 +173,14 @@ void k4GeneratorsConfig::xsection2Root::writeHistos(){
     mg->GetYaxis()->SetTitle("#sigma [pb]");
 
     name << m_processesList[proc] << ".png";
-    c1->BuildLegend(0.55,0.55,0.9,0.9);
+    c1->BuildLegend(0.55, 0.55, 0.9, 0.9);
     c1->Print(name.str().c_str());
 
     // clear and delete
-    name.clear(); name.str("");
-    delete mg; mg=0;
+    name.clear();
+    name.str("");
+    delete mg;
+    mg = 0;
 
     // and now the profile, draw first, then modify
     m_profiles[proc]->Draw();
@@ -189,11 +191,13 @@ void k4GeneratorsConfig::xsection2Root::writeHistos(){
     m_profiles[proc]->GetXaxis()->SetTitle("#sqrt{s} [GeV");
     m_profiles[proc]->GetYaxis()->SetTitle("#sigma [pb]");
 
-    name << m_processesList[proc] << "Profile" << ".png";
+    name << m_processesList[proc] << "Profile"
+         << ".png";
     c1->Print(name.str().c_str());
 
     // clear and delete
-    name.clear(); name.str("");
+    name.clear();
+    name.str("");
 
     // and now the profile but as Averae, draw first, then modify
     m_rms[proc]->Draw();
@@ -205,16 +209,15 @@ void k4GeneratorsConfig::xsection2Root::writeHistos(){
     m_rms[proc]->GetXaxis()->SetTitle("#sqrt{s} [GeV");
     m_rms[proc]->GetYaxis()->SetTitle("RMS(Generators)/Average(Generators)");
 
-    name << m_processesList[proc] << "RMS" << ".png";
+    name << m_processesList[proc] << "RMS"
+         << ".png";
     c1->Print(name.str().c_str());
 
     // clear and delete
-    name.clear(); name.str("");
-
+    name.clear();
+    name.str("");
   }
 
-  delete c1; 
+  delete c1;
 }
-void k4GeneratorsConfig::xsection2Root::writeTree(){
-  m_tree->Write();
-}
+void k4GeneratorsConfig::xsection2Root::writeTree() { m_tree->Write(); }

--- a/k4GeneratorsConfig/src/xsection2Root.h
+++ b/k4GeneratorsConfig/src/xsection2Root.h
@@ -2,11 +2,11 @@
 #define K4GENERATORSCONFIG_XSECTION2ROOT_H
 
 #include "TFile.h"
-#include "TTree.h"
-#include "TProfile.h"
+#include "TGraphErrors.h"
 #include "TH1D.h"
 #include "TH2D.h"
-#include "TGraphErrors.h"
+#include "TProfile.h"
+#include "TTree.h"
 
 #include <string>
 #include <unordered_map>
@@ -15,7 +15,7 @@
 
 namespace k4GeneratorsConfig {
 class xsection2Root {
- public:
+public:
   xsection2Root();
   xsection2Root(std::string);
   ~xsection2Root();
@@ -23,33 +23,32 @@ class xsection2Root {
   void Init();
   void Execute(xsection&);
   void Finalize();
-  
+
   void add2Tree(xsection&);
   void writeTree();
   void writeHistos();
 
-
- private:
-  TFile *m_file;
-  TTree *m_tree;
-  std::vector<TH2D*>         m_histos;
-  std::vector<TProfile*>     m_profiles;
-  std::vector<TH1D*>         m_rms;
+private:
+  TFile* m_file;
+  TTree* m_tree;
+  std::vector<TH2D*> m_histos;
+  std::vector<TProfile*> m_profiles;
+  std::vector<TH1D*> m_rms;
   std::vector<TGraphErrors*> m_graphs;
-  std::vector<TGraph*>       m_graphsDelta;
+  std::vector<TGraph*> m_graphsDelta;
 
   // data members
-  std::string  m_process;
-  int          m_processCode;
-  double       m_crossSection;
-  double       m_crossSectionError;
-  double       m_sqrts;
-  std::string  m_generator;
-  int m_generatorCode;  
+  std::string m_process;
+  int m_processCode;
+  double m_crossSection;
+  double m_crossSectionError;
+  double m_sqrts;
+  std::string m_generator;
+  int m_generatorCode;
 
   std::vector<std::string> m_generatorsList;
   std::vector<std::string> m_processesList;
 };
-}
+} // namespace k4GeneratorsConfig
 
 #endif

--- a/k4GeneratorsConfig/src/xsectionCollection.cxx
+++ b/k4GeneratorsConfig/src/xsectionCollection.cxx
@@ -1,37 +1,30 @@
 #include "xsectionCollection.h"
 #include "xsection2Root.h"
-#include <filesystem>
 #include <algorithm>
+#include <filesystem>
 #include <iostream>
 #include <sys/stat.h>
 
-k4GeneratorsConfig::xsectionCollection::xsectionCollection():
-  m_validCounter(0),
-  m_invalidCounter(0)
-{
-
-}
-k4GeneratorsConfig::xsectionCollection::xsectionCollection(const xsectionCollection& theOriginal)
-{
-  if ( this != &theOriginal ){
+k4GeneratorsConfig::xsectionCollection::xsectionCollection() : m_validCounter(0), m_invalidCounter(0) {}
+k4GeneratorsConfig::xsectionCollection::xsectionCollection(const xsectionCollection& theOriginal) {
+  if (this != &theOriginal) {
     m_xsectionCollection = theOriginal.m_xsectionCollection;
-    m_validCounter       = theOriginal.m_validCounter;
-    m_invalidCounter     = theOriginal.m_invalidCounter;
+    m_validCounter = theOriginal.m_validCounter;
+    m_invalidCounter = theOriginal.m_invalidCounter;
   }
 }
-k4GeneratorsConfig::xsectionCollection& k4GeneratorsConfig::xsectionCollection::operator=(const xsectionCollection& theOriginal)
-{
-  if ( this != &theOriginal ){
+k4GeneratorsConfig::xsectionCollection&
+k4GeneratorsConfig::xsectionCollection::operator=(const xsectionCollection& theOriginal) {
+  if (this != &theOriginal) {
     m_xsectionCollection = theOriginal.m_xsectionCollection;
-    m_validCounter       = theOriginal.m_validCounter;
-    m_invalidCounter     = theOriginal.m_invalidCounter;
+    m_validCounter = theOriginal.m_validCounter;
+    m_invalidCounter = theOriginal.m_invalidCounter;
   }
 
   return *this;
 }
-k4GeneratorsConfig::xsectionCollection::~xsectionCollection(){
-}
-void k4GeneratorsConfig::xsectionCollection::Execute(){
+k4GeneratorsConfig::xsectionCollection::~xsectionCollection() {}
+void k4GeneratorsConfig::xsectionCollection::Execute() {
 
   // first make the collection
   makeCollection();
@@ -42,62 +35,68 @@ void k4GeneratorsConfig::xsectionCollection::Execute(){
   // third print the final results
   Print();
 }
-void k4GeneratorsConfig::xsectionCollection::makeCollection(){
+void k4GeneratorsConfig::xsectionCollection::makeCollection() {
 
   for (const auto& yamls : std::filesystem::directory_iterator(".")) {
     std::filesystem::path yamlsPath = yamls.path();
     //    if ( yamlsPath.extension() == ".yaml" ) continue;
-    if ( !std::filesystem::is_directory(yamlsPath) ) continue;
+    if (!std::filesystem::is_directory(yamlsPath))
+      continue;
 
-    for (const auto& generators : std::filesystem::directory_iterator(yamlsPath.string()+"/Run-Cards")) {
+    for (const auto& generators : std::filesystem::directory_iterator(yamlsPath.string() + "/Run-Cards")) {
       std::filesystem::path generatorsPath = generators.path();
-      if ( !std::filesystem::is_directory(generatorsPath) ) continue;
+      if (!std::filesystem::is_directory(generatorsPath))
+        continue;
 
       for (const auto& procs : std::filesystem::directory_iterator(generatorsPath.string())) {
-	std::filesystem::path processPath = procs.path();
-	if ( !std::filesystem::is_directory(processPath) ) continue;
+        std::filesystem::path processPath = procs.path();
+        if (!std::filesystem::is_directory(processPath))
+          continue;
 
-	for (const auto& files : std::filesystem::directory_iterator(processPath.string())) {
-	  std::filesystem::path filenamePath = files.path();
-	  if ( !std::filesystem::is_regular_file(filenamePath) ) continue;
-	  if ( filenamePath.extension() == ".edm4hep" ){
-	    std::cout << "xsectionCollection:: processing " << processPath.filename().string() << std::endl;
-	    k4GeneratorsConfig::xsection *xsec = new k4GeneratorsConfig::xsection();
-	    xsec->setProcess(processPath.filename().string());
-	    xsec->setFile(filenamePath.string());
-	    // in some cases the generator name is not available, then derive from the filenam
-	    if ( xsec->Generator().empty() )
-	      xsec->setGenerator(generatorsPath.filename().string());
-	    std::cout << "Generator " << xsec->Generator() << " has been processed" << std::endl;
-	    m_xsectionCollection.push_back(*xsec);
-	    if ( xsec->isValid()  ) m_validCounter++;
-	    if ( !xsec->isValid() ) m_invalidCounter++;
-	    delete xsec;
-	  }
-	}
+        for (const auto& files : std::filesystem::directory_iterator(processPath.string())) {
+          std::filesystem::path filenamePath = files.path();
+          if (!std::filesystem::is_regular_file(filenamePath))
+            continue;
+          if (filenamePath.extension() == ".edm4hep") {
+            std::cout << "xsectionCollection:: processing " << processPath.filename().string() << std::endl;
+            k4GeneratorsConfig::xsection* xsec = new k4GeneratorsConfig::xsection();
+            xsec->setProcess(processPath.filename().string());
+            xsec->setFile(filenamePath.string());
+            // in some cases the generator name is not available, then derive from the filenam
+            if (xsec->Generator().empty())
+              xsec->setGenerator(generatorsPath.filename().string());
+            std::cout << "Generator " << xsec->Generator() << " has been processed" << std::endl;
+            m_xsectionCollection.push_back(*xsec);
+            if (xsec->isValid())
+              m_validCounter++;
+            if (!xsec->isValid())
+              m_invalidCounter++;
+            delete xsec;
+          }
+        }
       }
     }
   }
-
 }
-void k4GeneratorsConfig::xsectionCollection::orderCollection(){
+void k4GeneratorsConfig::xsectionCollection::orderCollection() {
 
   // order by length
-  //std::sort(m_xsectionCollection.begin(),m_xsectionCollection.end(),[this](xsection A, xsection B){ return this->compareLength(A,B);});
+  // std::sort(m_xsectionCollection.begin(),m_xsectionCollection.end(),[this](xsection A, xsection B){ return
+  // this->compareLength(A,B);});
 
   // order by content
-  std::sort(m_xsectionCollection.begin(),m_xsectionCollection.end(),[this](xsection A, xsection B){ return this->compareLexical(A,B);});
-
+  std::sort(m_xsectionCollection.begin(), m_xsectionCollection.end(),
+            [this](xsection A, xsection B) { return this->compareLexical(A, B); });
 }
-bool k4GeneratorsConfig::xsectionCollection::compareLength(xsection A, xsection B){
+bool k4GeneratorsConfig::xsectionCollection::compareLength(xsection A, xsection B) {
 
   // retrieve the process as ordering variable
   std::string processA = A.Process();
   std::string processB = B.Process();
-  
+
   return processA.size() < processB.size();
 }
-bool k4GeneratorsConfig::xsectionCollection::compareLexical(xsection A, xsection B){
+bool k4GeneratorsConfig::xsectionCollection::compareLexical(xsection A, xsection B) {
 
   // retrieve the process as ordering variable
   std::string processNgenA = A.Process() + A.Generator();
@@ -106,75 +105,69 @@ bool k4GeneratorsConfig::xsectionCollection::compareLexical(xsection A, xsection
   std::vector<std::string> listOf2;
   listOf2.push_back(processNgenA);
   listOf2.push_back(processNgenB);
-  sort(listOf2.begin(),listOf2.end());
+  sort(listOf2.begin(), listOf2.end());
 
   // if the order is changed return true otherwise false
-  if ( processNgenA.compare(listOf2[0]) == 0 ) return true;
-  
+  if (processNgenA.compare(listOf2[0]) == 0)
+    return true;
+
   return false;
 }
-unsigned int k4GeneratorsConfig::xsectionCollection::NbOfSuccesses(){
-  return m_validCounter;
-}
-unsigned int k4GeneratorsConfig::xsectionCollection::NbOfFailures(){
-  return m_invalidCounter;
-}
-void k4GeneratorsConfig::xsectionCollection::Write2Root(std::string filename){
+unsigned int k4GeneratorsConfig::xsectionCollection::NbOfSuccesses() { return m_validCounter; }
+unsigned int k4GeneratorsConfig::xsectionCollection::NbOfFailures() { return m_invalidCounter; }
+void k4GeneratorsConfig::xsectionCollection::Write2Root(std::string filename) {
 
-  xsection2Root out(filename); 
-  
-  for (auto xsec: m_xsectionCollection){
-    if ( xsec.isValid() ){
+  xsection2Root out(filename);
+
+  for (auto xsec : m_xsectionCollection) {
+    if (xsec.isValid()) {
       out.Execute(xsec);
     }
   }
   out.Finalize();
-  
 }
-void k4GeneratorsConfig::xsectionCollection::Print(bool onlyOK){
-  
-  for (auto xsec: m_xsectionCollection){
-    if ( !onlyOK ){
+void k4GeneratorsConfig::xsectionCollection::Print(bool onlyOK) {
+
+  for (auto xsec : m_xsectionCollection) {
+    if (!onlyOK) {
       xsec.Print();
-    }
-    else {
-      if ( xsec.isValid() ){
-	xsec.Print();
+    } else {
+      if (xsec.isValid()) {
+        xsec.Print();
       }
     }
-
   }
 }
-void k4GeneratorsConfig::xsectionCollection::PrintSummary(std::ostream &output) const {
+void k4GeneratorsConfig::xsectionCollection::PrintSummary(std::ostream& output) const {
 
-  std::string previousProcess= "XXXX";
-  for (auto xsec: m_xsectionCollection){
+  std::string previousProcess = "XXXX";
+  for (auto xsec : m_xsectionCollection) {
     // only print valid cross sections
-    if ( !xsec.isValid() ) continue;
+    if (!xsec.isValid())
+      continue;
     // if it's a new process print a new line
-    std::string proc     = xsec.Process();
+    std::string proc = xsec.Process();
     std::string filename = xsec.File();
-    if ( proc.compare(previousProcess) != 0 ){
-      if ( previousProcess.compare("XXXX")!= 0 ) output << std::endl;
+    if (proc.compare(previousProcess) != 0) {
+      if (previousProcess.compare("XXXX") != 0)
+        output << std::endl;
       output << proc << " sqrts= " << xsec.SQRTS();
-      if ( filename.find("ISR") != std::string::npos ) {
-	output << " with ISR ";
-	if ( filename.find("BST") != std::string::npos ) {
-	  output << " with Beamstrahlung ";
-	}
-      } 
+      if (filename.find("ISR") != std::string::npos) {
+        output << " with ISR ";
+        if (filename.find("BST") != std::string::npos) {
+          output << " with Beamstrahlung ";
+        }
+      }
       output << ":" << std::endl;
       previousProcess = proc;
     }
     // print the generator name and cross section with its error
-    output << std::setw(20) << std::left << xsec.Generator() << " " 
-	   << std::setw(8 ) << std::left << xsec.Xsection() << " +- " 
-	   << std::setw(8)  << std::left << xsec.XsectionError() << " pb" << std::endl;
+    output << std::setw(20) << std::left << xsec.Generator() << " " << std::setw(8) << std::left << xsec.Xsection()
+           << " +- " << std::setw(8) << std::left << xsec.XsectionError() << " pb" << std::endl;
   }
   output << std::endl;
   // last thing the invalids
-  output << "Number of runs           : " << m_invalidCounter+m_validCounter << std::endl;
+  output << "Number of runs           : " << m_invalidCounter + m_validCounter << std::endl;
   output << "Number of failed runs    : " << m_invalidCounter << std::endl;
   output << "Number of successful runs: " << m_validCounter << std::endl;
-
 }

--- a/k4GeneratorsConfig/src/xsectionCollection.h
+++ b/k4GeneratorsConfig/src/xsectionCollection.h
@@ -7,7 +7,7 @@
 
 namespace k4GeneratorsConfig {
 class xsectionCollection {
- public:
+public:
   xsectionCollection();
   xsectionCollection(const xsectionCollection&);
   xsectionCollection& operator=(const xsectionCollection&);
@@ -21,18 +21,17 @@ class xsectionCollection {
 
   unsigned int NbOfSuccesses();
   unsigned int NbOfFailures();
-  
+
   void Write2Root(std::string);
 
-  void Print(bool onlyOK=false);
-  void PrintSummary(std::ostream &output=std::cout) const;
+  void Print(bool onlyOK = false);
+  void PrintSummary(std::ostream& output = std::cout) const;
 
- private:
+private:
   std::vector<k4GeneratorsConfig::xsection> m_xsectionCollection;
   unsigned int m_validCounter;
   unsigned int m_invalidCounter;
-  
 };
-}
+} // namespace k4GeneratorsConfig
 
 #endif

--- a/k4GeneratorsConfig/src/xsectionSummary.cxx
+++ b/k4GeneratorsConfig/src/xsectionSummary.cxx
@@ -1,18 +1,17 @@
 // File to read EDM4HEP output and extract the cross sections
-#include <iostream>
-#include <fstream>
-#include <unistd.h>
 #include "xsectionCollection.h"
+#include <fstream>
+#include <iostream>
+#include <unistd.h>
 
 //
-int main(int argc, char** argv)
-{
+int main(int argc, char** argv) {
 
-  std::string filename="XsectionSummary.dat";
-  std::string fileRoot="XsectionSummary.root";
+  std::string filename = "XsectionSummary.dat";
+  std::string fileRoot = "XsectionSummary.root";
   int c;
-  while ((c = getopt (argc, argv, "hf:r:")) != -1)
-    switch (c){
+  while ((c = getopt(argc, argv, "hf:r:")) != -1)
+    switch (c) {
     case 'f':
       filename = optarg;
       break;
@@ -30,22 +29,24 @@ int main(int argc, char** argv)
     }
 
   // instantiate the collection as pointer
-  k4GeneratorsConfig::xsectionCollection *xsecColl = new k4GeneratorsConfig::xsectionCollection();
+  k4GeneratorsConfig::xsectionCollection* xsecColl = new k4GeneratorsConfig::xsectionCollection();
   // execute the gathering of information including detailed output
   xsecColl->Execute();
   // print the summary on screen
   xsecColl->PrintSummary(std::cout);
   // save the summary in a file
   std::ofstream outFile(filename);
-  std::ostream &output = outFile;
+  std::ostream& output = outFile;
   xsecColl->PrintSummary(output);
   // write to root
   xsecColl->Write2Root(fileRoot);
   // if there is a failure:
-  if ( xsecColl->NbOfFailures() != 0 ){
-    std::cout << xsecColl->NbOfFailures() << "/" << xsecColl->NbOfFailures() + xsecColl->NbOfSuccesses() << " Runs failed" << std::endl;
+  if (xsecColl->NbOfFailures() != 0) {
+    std::cout << xsecColl->NbOfFailures() << "/" << xsecColl->NbOfFailures() + xsecColl->NbOfSuccesses()
+              << " Runs failed" << std::endl;
     exit(1);
   }
   // delete the pointer
-  delete xsecColl; xsecColl=0;
+  delete xsecColl;
+  xsecColl = 0;
 }

--- a/python/Generators/Babayaga.py
+++ b/python/Generators/Babayaga.py
@@ -56,7 +56,7 @@ class Babayaga(GeneratorBase):
         # procDB
         for key in self.procDB.getDict():
             self.addOption2GeneratorDatacard(key,self.procDB.getDict()[key])
-        
+
         if self.procinfo.eventmode == "unweighted":
             self.addOption2GeneratorDatacard("mode", "unweighted")
         else:

--- a/python/Generators/GeneratorBase.py
+++ b/python/Generators/GeneratorBase.py
@@ -20,9 +20,9 @@ class GeneratorBase(abc.ABC):
 
         # set the default model parameters:
         self.setDefaultModelParameters()
-        # set the Generator specific parameters 
+        # set the Generator specific parameters
         self.setModelParameters()
-        
+
         # define the output directory as function of the OutDir spec + generator name + process name
         self.outdir = (
             f"{procinfo.get('OutDir')}/{self.name}/{self.procinfo.get('procname')}"
@@ -55,8 +55,8 @@ class GeneratorBase(abc.ABC):
         # four types of global variables for the file content
         self.__datacardContent = ""
         self.__key4hepContent  = ""
-        self.__analysisContent = "" 
-        self.__optfileContent  = "" 
+        self.__analysisContent = ""
+        self.__optfileContent  = ""
 
         # optional file configuration
         self.__optionalFileExtension = ""
@@ -66,7 +66,7 @@ class GeneratorBase(abc.ABC):
 
         # the KEY4HEP environment setup is independent of the generator, so we can prepare it at the initialization stage:
         self.prepareKey4hepScript()
-        
+
         # the analysis depends only on the process, not on the generator, so we can prepare it at the initialization stage:
         self.prepareAnalysisContent()
 
@@ -98,7 +98,7 @@ class GeneratorBase(abc.ABC):
             print(f"Execution of {self.procDBName} for {self.procinfo.get('_proclabel')} resulted in an exception")
             print("Datacard files and execution scripts not written for this generator")
             raise
-        
+
         self.procDBparameters  = dict()
         self.procDBparticles  = dict()
         if self.settings.get("usedefaults", True):
@@ -113,7 +113,7 @@ class GeneratorBase(abc.ABC):
         except:
             theModel = self.getModelName(self.procinfo.get('model'))
         return theModel
-            
+
     def getModelName(self):
         raise NotImplementedError("getModelName")
 
@@ -125,7 +125,7 @@ class GeneratorBase(abc.ABC):
         self.addModelParticleProperty(pdg_code=6, property_type='width')
         self.addModelParticleProperty(pdg_code=25, property_type='mass')
         self.addModelParticleProperty(pdg_code=25, property_type='width')
-        
+
     def setModelParameters(self):
         raise NotImplementedError("setModelParameters")
 
@@ -179,11 +179,11 @@ class GeneratorBase(abc.ABC):
     def getGeneratorDatacard(self):
         # return content
         return self.__datacardContent
-       
+
     def resetGeneratorDatacard(self):
         # data encapsulation: reset the datacard content to ""
         self.__datacardContent = ""
-       
+
     def getGeneratorCommand(self,key,value):
         raise NotImplementedError("getGeneratorCommand")
 
@@ -275,7 +275,7 @@ class GeneratorBase(abc.ABC):
                 particle[prop] = value
             except:
                 particleCollection[pdgstr] = { prop : value }
-                
+
         # now as last step we overwrite with the yaml if present:
         # retrieve the particles from the input
         for yamlParticle in self.procinfo.get_data_particles():
@@ -309,7 +309,7 @@ class GeneratorBase(abc.ABC):
                         self.addOption2GeneratorDatacard(command, value,replace=False)
                     else:
                         self.replaceOptionInGeneratorDatacard(command,value)
-                
+
     def getParticleProperty(self, attr):
         raise NotImplementedError("getParticleProperty")
 
@@ -319,41 +319,41 @@ class GeneratorBase(abc.ABC):
     def add2Key4hepScript(self,content):
         # data encapsulation: add to the content in the base class
         self.__key4hepContent += content
-        
+
     def getKey4hepScript(self):
         # return content
         return self.__key4hepContent
-        
+
     def resetKey4hepScript(self):
         # data encapsulation: reset the  KEY4HEP script content to ""
         self.__key4hepContent = ""
-        
+
     def add2Analysis(self,content):
         # data encapsulation: add to the content in the base class
         self.__analysisContent += content
-        
+
     def getAnalysis(self):
         # return content
         return self.__analysisContent
-        
+
     def resetAnalysis(self):
         # data encapsulation: reset analysis content to ""
         self.__analysisContent = ""
-        
+
     def add2OptionalFile(self,content):
         # data encapsulation: add to the content in the base class
         if not self.__optionalFileUsed:
             self.__optionalFileUsed = True
         self.__optfileContent += content
-       
+
     def getOptionalFileContent(self):
         # return content
         return self.__optfileContent
-       
+
     def resetOptionalFile(self):
         # data encapsulation: reset the optionalFile content to ""
         self.__optfileContent = ""
-       
+
     def setOptionalFileNameAndExtension(self,filename,extension):
         # data encapsulation: reset the optionalFile content to ""
         self.__optionalFileExtension = extension
@@ -361,10 +361,10 @@ class GeneratorBase(abc.ABC):
         self.__optionalFile          = f"{self.outdir}/{filename}.{self.__optionalFileExtension}"
         if not self.__optionalFileUsed:
             self.__optionalFileUsed = True
-       
+
     def getOptionalFileName(self):
         return self.__optionalFileName
-       
+
     def readTemplateFile(self):
         # Load default settigns
         try:
@@ -373,10 +373,10 @@ class GeneratorBase(abc.ABC):
         except FileNotFoundError as e:
             print("Cannot configure KKMC: Template file not found with error:\n"+str(e))
         return ""
-       
+
     def getTemplateFile(self):
         return f"{os.path.dirname(__file__)}/{self.name}.template"
-       
+
     def prepareKey4hepScript(self):
         # set up for key4hep run of event generation
         key4hep_config = "#!/usr/bin/env bash\n"
@@ -426,14 +426,14 @@ class GeneratorBase(abc.ABC):
         # write the RIVET analysis
         if self.settings.rivetON():
             yodaout = self.settings.yodaoutput + f"/{self.procinfo.get('procname')}.yoda"
-            analysis += f"rivet" 
+            analysis += f"rivet"
             for ana in self.settings.analysisname:
                 analysis += f" -a {ana}"
             analysis+=f" -o {yodaout} {self.procinfo.get('procname')}.{self.procinfo.get('output_format')}\n"
 
         # add to the text to the data member
         self.add2Analysis(analysis)
-    
+
     def finalize(self):
         # the content has been filled, now we write to disk
         self.writeGeneratorDatacard()

--- a/python/Generators/KKMC.py
+++ b/python/Generators/KKMC.py
@@ -32,7 +32,7 @@ class KKMC(GeneratorBase):
         self.fill_datacard()
         # prepare the key4hep script
         self.fill_key4hepScript()
-        
+
     def fill_datacard(self):
         if (
             abs(self.procinfo.get_beam_flavour(1)) != 11
@@ -97,7 +97,7 @@ class KKMC(GeneratorBase):
 
     def getParameterLabel(self, param):
         parameterDict = { 'GFermi' : '_GFermi', 'alphaSMZ' : '_alphaSMZ', 'alphaEMM1': '_alphaEMM1'}
-        # alphas could be SigmaProcess:alphaSvalue 
+        # alphas could be SigmaProcess:alphaSvalue
         if param not in parameterDict.keys():
             print(f"Warning::KKMC: parameter {param} has no translation in KKMC Parameter Dictionary")
             return ""

--- a/python/Generators/Madgraph.py
+++ b/python/Generators/Madgraph.py
@@ -15,7 +15,7 @@ class Madgraph(GeneratorBase):
 
         self.setOptionalFileNameAndExtension(f"pythia{self.GeneratorDatacardBase}","cmnd")
         self.fill_PythiaCMND()
-        
+
     def setModelParameters(self):
         # no alphaS and MZ, these are default
         self.addModelParameter('GFermi')
@@ -95,11 +95,11 @@ class Madgraph(GeneratorBase):
                  return f"{accel}240ll"
             else:
                  return f"fcc365ll"
-             
+
         elif accel == "ilc":
             # only one option implemented
             return f"{accel}500ll"
-        
+
         elif accel == "clic":
             # only one option implemented
             return f"{accel}3000ll"
@@ -291,7 +291,7 @@ class Madgraph(GeneratorBase):
 
     def getParameterLabel(self, param):
         parameterDict = { 'GFermi' : 'GF', 'alphaSMZ' : 'aS', 'alphaEMM1' : 'aEWM1' , 'alphaEMEWSchemeM1' : 'aEWM1'}
-        # alphas could be SigmaProcess:alphaSvalue 
+        # alphas could be SigmaProcess:alphaSvalue
         if param not in parameterDict.keys():
             print(f"Warning::Madgraph: parameter {param} has no translation in Madgraph Parameter Dictionary")
             return ""

--- a/python/Generators/ProcDBBase.py
+++ b/python/Generators/ProcDBBase.py
@@ -13,7 +13,7 @@ class ProcDBBase(abc.ABC):
 
     def execute(self):
         return
-        
+
     def getDict(self):
         fulldict = dict()
         fulldict.update(self.rundict)

--- a/python/Generators/Pythia.py
+++ b/python/Generators/Pythia.py
@@ -164,11 +164,11 @@ class Pythia(GeneratorBase):
                     or str(f2) not in self.procinfo.get_final_pdg()
                 ):
                     continue
-                
+
             sname = f"2 {name} {f1} {f2} > {Min}"
             if f" {name} {f1} {f2} >" not in self.getOptionalFileContent():
                 self.add2OptionalFile(f"{sname}\n")
-                
+
             sname = f"2 {f1} {f2} {name} < {Max}"
             if f"  {f1} {f2} {name} <" not in self.cuts:
                 self.cuts += f"{sname}\n"
@@ -228,7 +228,7 @@ class Pythia(GeneratorBase):
         parameterDict = { 'alphaEMMZ' : 'alphaEMmZ', 'GFermi' : 'GF',
                           'sin2theta' : 'sin2thetaW', 'sin2thetaEff': 'sin2thetaWbar',
                           'alphaSMZ' : 'alphaSvalueMRun'}
-        # alphas could be SigmaProcess:alphaSvalue 
+        # alphas could be SigmaProcess:alphaSvalue
         if param not in parameterDict.keys():
             print(f"Warning::Pythia: parameter {param} has no translation in Pythia Parameter Dictionary")
             return ""
@@ -239,7 +239,7 @@ class Pythia(GeneratorBase):
             return f"StandardModel:{name}"
         else:
             return f"ParticleData:{name}"
-        # return f"SigmaProcess:{name}"     
+        # return f"SigmaProcess:{name}"
 
     def getParticleProperty(self, d):
         name = None

--- a/python/Generators/PythiaProcDB.py
+++ b/python/Generators/PythiaProcDB.py
@@ -57,7 +57,7 @@ class PythiaProcDB(ProcDBBase):
             self.write_run_ZH()
         elif label == "11_11_12_12_25":
             self.write_run_Hnunu()
-            
+
     def write_Difermion(self, pdg):
         self.procdict['WeakSingleBoson:ffbar2gmZ'] = "on"
         self.procdict['22:onMode']  = "off"
@@ -71,11 +71,11 @@ class PythiaProcDB(ProcDBBase):
     def write_ZZ(self):
         self.procdict['WeakDoubleBoson:ffbar2gmZgmZ'] = "on"
         self.procdict['23:onMode'] = "on"
-        
+
     def write_WW(self):
         self.procdict['WeakDoubleBoson:ffbar2WW'] = "on"
         self.procdict['24:onMode'] = "on"
-    
+
     def write_run_ZH(self):
         self.procdict['HiggsSM:ffbar2HZ'] = "on"
         self.procdict['25:onMode'] = "on"

--- a/python/Generators/Sherpa.py
+++ b/python/Generators/Sherpa.py
@@ -21,7 +21,7 @@ class Sherpa(GeneratorBase):
         self.fill_datacard()
         # prepare the key4hep script
         self.fill_key4hepScript()
-        
+
     def write_run(self):
         self.addOption2GeneratorDatacard("RANDOM_SEED", self.procinfo.get_rndmSeed())
 
@@ -55,7 +55,7 @@ class Sherpa(GeneratorBase):
         # run settings
         for key in self.procDB.getDictParameters():
             self.addOption2GeneratorDatacard(key,self.procDB.getDict()[key])
-        
+
         self.addOption2GeneratorDatacard("EVENT_GENERATION_MODE", self.procinfo.eventmode)
         if self.gen_settings is not None:
             if "run" in self.gen_settings.keys():
@@ -216,7 +216,7 @@ class Sherpa(GeneratorBase):
 
     def getParameterLabel(self, param):
         parameterDict = { 'GFermi' : 'GF', 'alphaSMZ' : 'ALPHAS(MZ)' }
-        # alphas could be SigmaProcess:alphaSvalue 
+        # alphas could be SigmaProcess:alphaSvalue
         if param not in parameterDict.keys():
             print(f"Warning::Sherpa: parameter {param} has no translation in Sherpa Parameter Dictionary")
             return ""

--- a/python/Generators/Sherpa2.py
+++ b/python/Generators/Sherpa2.py
@@ -21,7 +21,7 @@ class Sherpa2(GeneratorBase):
         self.fill_datacard()
         # prepare the key4hep script
         self.fill_key4hepScript()
-        
+
     def write_run(self):
         self.add2GeneratorDatacard("(run){\n")
 
@@ -66,7 +66,7 @@ class Sherpa2(GeneratorBase):
         # run settings
         for key in self.procDB.getDict():
             self.addOption2GeneratorDatacard(key,self.procDB.getDict()[key])
-        
+
         self.addOption2GeneratorDatacard("EVENT_GENERATION_MODE", self.procinfo.eventmode)
         if self.gen_settings is not None:
             if "run" in self.gen_settings.keys():
@@ -220,7 +220,7 @@ class Sherpa2(GeneratorBase):
 
     def getParameterLabel(self, param):
         parameterDict = { 'GFermi' : 'GF', 'alphaSMZ' : 'ALPHAS(MZ)' }
-        # alphas could be SigmaProcess:alphaSvalue 
+        # alphas could be SigmaProcess:alphaSvalue
         if param not in parameterDict.keys():
             print(f"Warning::Sherpa2: parameter {param} has no translation in Sherpa2 Parameter Dictionary")
             return ""

--- a/python/Generators/Sherpa2ProcDB.py
+++ b/python/Generators/Sherpa2ProcDB.py
@@ -18,5 +18,5 @@ class Sherpa2ProcDB(ProcDBBase):
             self.rundict['MASSIVE[15]'] = 1
         # the electroweak scheme is common to all implemented processes so far
         self.rundict['EW_SCHEME'] = 3
-        
-            
+
+

--- a/python/Generators/SherpaProcDB.py
+++ b/python/Generators/SherpaProcDB.py
@@ -25,5 +25,5 @@ class SherpaProcDB(ProcDBBase):
             self.particlesdict['4']  = {'Massive' : 1}
         # the electroweak scheme is common to all implemented processes so far
         self.rundict['EW_SCHEME'] = 3
-        
-            
+
+

--- a/python/Generators/Whizard.py
+++ b/python/Generators/Whizard.py
@@ -18,7 +18,7 @@ class Whizard(GeneratorBase):
         self.addModelParticleProperty(pdg_code=23, property_type='mass')
         self.addModelParticleProperty(pdg_code=23, property_type='width')
         self.addModelParticleProperty(pdg_code=24, property_type='width')
-        
+
     def execute(self):
         # prepare the datacard
         self.fill_datacard()
@@ -84,7 +84,7 @@ class Whizard(GeneratorBase):
 
         for key in self.procDB.getDict():
             self.addOption2GeneratorDatacard(key,self.procDB.getDict()[key])
-            
+
         if self.procinfo.eventmode == "unweighted":
             self.addOption2GeneratorDatacard("?unweighted", "true")
         else:
@@ -219,7 +219,7 @@ class Whizard(GeneratorBase):
         parameterDict = { 'GFermi' : 'GF', 'alphaSMZ' : 'alphas',
                           'MZ' : 'mass', 'WZ' : 'width', 'MW' : 'mass', 'WW' : 'width',
                           'MB' : 'mass', 'MT' : 'mass', 'WT' : 'width', 'MH': 'mass', 'WH' : 'width'}
-        # alphas could be SigmaProcess:alphaSvalue 
+        # alphas could be SigmaProcess:alphaSvalue
         if param not in parameterDict.keys():
             print(f"Warning::Whizard: parameter {param} has no translation in Whizard Parameter Dictionary")
             return ""

--- a/python/Input.py
+++ b/python/Input.py
@@ -210,7 +210,7 @@ class Input:
     def rivetON(self):
         if self.anatools is not None:
             return "rivet" in self.anatools
-        
+
 
     def key4HEPAnalysisON(self):
         if self.anatools is not None:

--- a/python/ParameterSets.yaml
+++ b/python/ParameterSets.yaml
@@ -1,7 +1,7 @@
-latest : 
+latest :
     alphaSMZ : 0.1184
-    GFermi   : 0.0000116637 
+    GFermi   : 0.0000116637
 
-oldest : 
+oldest :
     alphaSMZ : 4714
     GFermi : 4715

--- a/python/main.py
+++ b/python/main.py
@@ -54,7 +54,7 @@ ParticleData : overwrite basic particle properties
 For MADGRAPH and Whizard only:
 PolarisationDensity  : float ([-1 or 0 or 1,1 or 0 or -1]) default: [-1, 1]
 PolarisationFraction : float ([0...1.,0....1.]), default [0,0]
-Beamstrahlung        : string (name of accelerator: ILC, FCC, CLIC, C3, HALFHF) 
+Beamstrahlung        : string (name of accelerator: ILC, FCC, CLIC, C3, HALFHF)
     """
         ),
     )
@@ -154,7 +154,7 @@ Beamstrahlung        : string (name of accelerator: ILC, FCC, CLIC, C3, HALFHF)
     except FileNotFoundError as e:
         print(f"ERROR: File {e} with parameters for tag {paramTag} not found")
         exit()
-    
+
     # now execute file processes
     if len(energies) == 0:
         executeFiles(files, 0, rndmSeed, events)

--- a/setup.csh
+++ b/setup.csh
@@ -26,7 +26,7 @@ set SrcDir=( Generators )
 foreach dir ( $SrcDir )
    if ( $?PYTHONPATH ) then
        setenv PYTHONPATH ${K4GenDir}/python/${dir}:$PYTHONPATH
-   else 
+   else
        setenv PYTHONPATH ${K4GenDir}/python/${dir}
    endif
 end

--- a/share/ECFAHiggsFactories/ffbar/ffbar.yaml
+++ b/share/ECFAHiggsFactories/ffbar/ffbar.yaml
@@ -22,7 +22,7 @@ Processes:
   MuonNeutrino:
      Final: [14, -14]
      Order: [2,0]
-  
+
   Tau:
      Final: [15, -15]
      Order: [2,0]

--- a/test/check-cards.sh
+++ b/test/check-cards.sh
@@ -25,7 +25,7 @@ while getopts ${OPTSTRING} opt; do
       runReducedEvgen="true"
       ;;
     h)
-      echo "Arguments are:" 
+      echo "Arguments are:"
       echo "-h for help"
       echo "-b to block the event generation step fully"
       echo "-r to reduce the number of event generation steps to 1 per yaml file"
@@ -56,9 +56,9 @@ function checkFile() {
     local outFile="$3"
     if [[ -e "$REFDIR/$refgenerator/$procname/$outFile" ]]; then
         if diff "$REFDIR/$refgenerator/$procname/$outFile" "$PWD/$generator/$procname/$outFile" &> /dev/null; then
-            echo "Process " $procname : "Files are identical for file" $outFile 
+            echo "Process " $procname : "Files are identical for file" $outFile
         else
-            echo "Process " $procname "Files are different for file" $outFile 
+            echo "Process " $procname "Files are different for file" $outFile
             diff "$REFDIR/$refgenerator/$procname/$outFile" "$PWD/$generator/$procname/$outFile"
             exit 1
         fi

--- a/test/check-runs.sh
+++ b/test/check-runs.sh
@@ -25,7 +25,7 @@ while getopts ${OPTSTRING} opt; do
       runReducedEvgen="true"
       ;;
     h)
-      echo "Arguments are:" 
+      echo "Arguments are:"
       echo "-h for help"
       echo "-b to block the event generation step fully"
       echo "-r to reduce the number of event generation steps to 1 per yaml file"
@@ -52,7 +52,7 @@ cd ci-setups
 
 function processRun() {
     isOK=0
-    topDir=${PWD} 
+    topDir=${PWD}
     thepath="$(dirname "$1")"
     runfile="$(basename "$1")"
     echo Running $runfile in $thepath
@@ -97,7 +97,7 @@ if [[ $runEvgen = "true" ]]; then
     	done
     else
         echo "No executables for this generator, continuing"
-        counter=$((counter+1))    
+        counter=$((counter+1))
         counterRan=$((counterRan+1))
     fi
 	cd ..

--- a/test/check.sh
+++ b/test/check.sh
@@ -25,7 +25,7 @@ while getopts ${OPTSTRING} opt; do
       runReducedEvgen="true"
       ;;
     h)
-      echo "Arguments are:" 
+      echo "Arguments are:"
       echo "-h for help"
       echo "-b to block the event generation step fully"
       echo "-r to reduce the number of event generation steps to 1 per yaml file"
@@ -56,9 +56,9 @@ function checkFile() {
     local outFile="$3"
     if [[ -e "$REFDIR/$refgenerator/$procname/$outFile" ]]; then
         if diff "$REFDIR/$refgenerator/$procname/$outFile" "$PWD/$generator/$procname/$outFile" &> /dev/null; then
-            echo "Process " $procname : "Files are identical for file" $outFile 
+            echo "Process " $procname : "Files are identical for file" $outFile
         else
-            echo "Process " $procname "Files are different for file" $outFile 
+            echo "Process " $procname "Files are different for file" $outFile
             diff "$REFDIR/$refgenerator/$procname/$outFile" "$PWD/$generator/$procname/$outFile"
             exit 1
         fi
@@ -102,7 +102,7 @@ done
 
 function processRun() {
     isOK=0
-    topDir=${PWD} 
+    topDir=${PWD}
     thepath="$(dirname "$1")"
     runfile="$(basename "$1")"
     echo Running $runfile in $thepath

--- a/test/checkGeneratorDatacards.sh
+++ b/test/checkGeneratorDatacards.sh
@@ -16,7 +16,7 @@ while getopts ${OPTSTRING} opt; do
       echo $0 will only check $GENERATOR
       ;;
     h)
-      echo "Arguments are:" 
+      echo "Arguments are:"
       echo "-h for help"
       echo "-g GENERATOR "
       exit 0
@@ -57,9 +57,9 @@ function checkFile() {
     local outFile="$3"
     if [[ -e "$REFDIR/$refgenerator/$procname/$outFile" ]]; then
         if diff "$REFDIR/$refgenerator/$procname/$outFile" "$PWD/$generator/$procname/$outFile" &> /dev/null; then
-            echo "Process " $procname : "Files are identical for file" $outFile 
+            echo "Process " $procname : "Files are identical for file" $outFile
         else
-            echo "Process " $procname "Files are different for file" $outFile 
+            echo "Process " $procname "Files are different for file" $outFile
             diff "$REFDIR/$refgenerator/$procname/$outFile" "$PWD/$generator/$procname/$outFile"
             exit 1
         fi

--- a/test/createGeneratorDatacardsFromYaml.sh
+++ b/test/createGeneratorDatacardsFromYaml.sh
@@ -20,7 +20,7 @@ while getopts ${OPTSTRING} opt; do
       echo only $YAMLFILE will be processed
       ;;
     h)
-      echo "Arguments are:" 
+      echo "Arguments are:"
       echo "-h for help"
       echo "-d YAMLDIRECTORY "
       exit 0

--- a/test/runEventGeneration.sh
+++ b/test/runEventGeneration.sh
@@ -16,7 +16,7 @@ while getopts ${OPTSTRING} opt; do
       GENERATOR="$OPTARG"
       ;;
     h)
-      echo "Arguments are:" 
+      echo "Arguments are:"
       echo "-h for help"
       echo "-g GENERATORNAME only run this generator"
       exit 0
@@ -38,7 +38,7 @@ cd ci-setups
 
 # run a generator: argument is a pathname
 function processRun() {
-    topDir=${PWD} 
+    topDir=${PWD}
     thepath="$(dirname "$1")"
     runfile="$(basename "$1")"
     echo Running $runfile in $thepath


### PR DESCRIPTION
BEGINRELEASENOTES
- Add the central `.clang-format` configuration from `key4hep-dev-utils` which is also present in other Key4hep repositories
- Add a basic pre-commit setup that enforces this formatting
- Format all (non-generated) c++ files according to the central configuration
- whitespace is only enforced on non-generated files and files that are used as reference result files

ENDRELEASENOTES

Also grown out of #35 as work that should help distinguishing between actual changes and simple format changes. In principle we also have a prescribed formatting guideline for python, but I haven't added that yet here, as it would affect more code and things that are more actively worked on.

This PR should be merged via rebase to keep the format commit intact, such that it can be added to a `.git-blame-ignore-revs` file in order to still have sensible git blame contents regardless of formatting changes.
