### PR TITLE
Add LANGUAGES CXX to the project call in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.25)
 
-project(k4GeneratorsConfig)
+project(k4GeneratorsConfig LANGUAGES CXX)
 
 # project version
 SET( ${PROJECT_NAME}_VERSION_MAJOR 0 )


### PR DESCRIPTION
BEGINRELEASENOTES
- Add LANGUAGES CXX to the project call in CMakeLists.txt to disable a check for a C compiler

ENDRELEASENOTES