### PR TITLE
Add ROOT to the packages that are required since it is linked to

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(EDM4HEP REQUIRED)
 find_package(HepMC3 REQUIRED)
 find_package(HepPDT REQUIRED)
 find_package(pythia8 REQUIRED)
+find_package(ROOT REQUIRED COMPONENTS Core Tree Hist)
 
 # --- optional dependencies for additional functionality via HepMC3
 find_package(ZLIB)


### PR DESCRIPTION
in https://github.com/key4hep/k4GeneratorsConfig/blob/main/k4GeneratorsConfig/CMakeLists.txt#L66