### PR TITLE
remove upload as now managed by key4hep actions

### DIFF
--- a/.github/workflows/key4hep_build.yml
+++ b/.github/workflows/key4hep_build.yml
@@ -32,9 +32,6 @@ jobs:
       if: ${{ !cancelled() }}
       with:
         name: k4GeneratorsConfig_report_${{ matrix.build_type }}_${{ matrix.image }}
-        path: |
-          test/Run-Cards/*.dat
-          test/Run-Cards/*.root
     - name: Show full CTest log on failure
       if: failure()
       run: |

--- a/.github/workflows/key4hep_build.yml
+++ b/.github/workflows/key4hep_build.yml
@@ -29,9 +29,6 @@ jobs:
         build_type: ${{ matrix.build_type }}
         image: ${{ matrix.image }}
     - uses: actions/upload-artifact@v4
-      if: ${{ !cancelled() }}
-      with:
-        name: k4GeneratorsConfig_report_${{ matrix.build_type }}_${{ matrix.image }}
     - name: Show full CTest log on failure
       if: failure()
       run: |

--- a/.github/workflows/key4hep_build.yml
+++ b/.github/workflows/key4hep_build.yml
@@ -28,7 +28,6 @@ jobs:
       with:
         build_type: ${{ matrix.build_type }}
         image: ${{ matrix.image }}
-    - uses: actions/upload-artifact@v4
     - name: Show full CTest log on failure
       if: failure()
       run: |


### PR DESCRIPTION
BEGINRELEASENOTES
- CI upload of results now managed by [https://github.com/key4hep/key4hep-actions](https://github.com/key4hep/key4hep-actions) remove the duplication
ENDRELEASENOTES
